### PR TITLE
/users/me 엔드포인트 구현 (GET / PATCH)

### DIFF
--- a/src/main/java/konkuk/ptal/config/JwtAuthenticationFilter.java
+++ b/src/main/java/konkuk/ptal/config/JwtAuthenticationFilter.java
@@ -25,7 +25,9 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
 
     // SecurityConfig에서 정의한 SWAGGER_PATHS를 여기서도 사용
     private static final String[] DEFAULT_PERMIT_PATHS = {
-            "/api/v1/auth/**",
+            "/api/v1/auth/signup/reviewer",
+            "/api/v1/auth/signup/reviewee",
+            "/api/v1/auth/signin",
             "/h2-console/**"
             // 다른 기본 허용 경로가 있다면 추가
     };

--- a/src/main/java/konkuk/ptal/config/JwtTokenProvider.java
+++ b/src/main/java/konkuk/ptal/config/JwtTokenProvider.java
@@ -38,6 +38,10 @@ public class JwtTokenProvider {
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
+        // UserPrincipal에서 userId 추출
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+        Long userId = userPrincipal.getUserId();
+
         long now = (new Date()).getTime();
         // Access Token 생성
         Date accessTokenExpiresIn = new Date(now + 7 * 24 * 60 * 60 * 1000);
@@ -45,6 +49,7 @@ public class JwtTokenProvider {
         String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())
                 .claim("auth", authorities)
+                .claim("userId", userId)  // userId 클레임 추가
                 .setExpiration(accessTokenExpiresIn)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -52,6 +57,7 @@ public class JwtTokenProvider {
         // Refresh Token 생성
         String refreshToken = Jwts.builder()
                 .setSubject(authentication.getName())
+                .claim("userId", userId)  // Refresh Token에도 userId 포함
                 .setExpiration(new Date(now + 7 * 24 * 60 * 60 * 1000))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -78,8 +84,11 @@ public class JwtTokenProvider {
                         .map(SimpleGrantedAuthority::new)
                         .toList();
 
+        // 클레임에서 userId 추출
+        Long userId = claims.get("userId", Long.class);
+
         // UserDetails 객체를 만들어서 Authentication 리턴
-        UserDetails principal = new UserPrincipal(claims.getSubject(), "", new ArrayList<>());
+        UserDetails principal = new UserPrincipal(userId, claims.getSubject(), "", new ArrayList<>());
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 

--- a/src/main/java/konkuk/ptal/config/JwtTokenProvider.java
+++ b/src/main/java/konkuk/ptal/config/JwtTokenProvider.java
@@ -3,8 +3,8 @@ package konkuk.ptal.config;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
-import konkuk.ptal.domain.UserPrincipal;
 import konkuk.ptal.domain.TokenInfo;
+import konkuk.ptal.domain.UserPrincipal;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -16,7 +16,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import java.security.Key;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
 import java.util.stream.Collectors;
 
 @Slf4j

--- a/src/main/java/konkuk/ptal/config/SecurityConfig.java
+++ b/src/main/java/konkuk/ptal/config/SecurityConfig.java
@@ -48,7 +48,10 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/auth/signup/reviewer").permitAll()
+                        .requestMatchers("/api/v1/auth/signup/reviewee").permitAll()
+                        .requestMatchers("/api/v1/auth/signin").permitAll()
+                        .requestMatchers("/api/v1/auth/signout").authenticated()
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers(SWAGGER_PATHS).permitAll() // Swagger 경로 허용
                         .requestMatchers("/api/v1/reviewer/**").authenticated()

--- a/src/main/java/konkuk/ptal/config/WebConfig.java
+++ b/src/main/java/konkuk/ptal/config/WebConfig.java
@@ -3,8 +3,8 @@ package konkuk.ptal.config;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 

--- a/src/main/java/konkuk/ptal/controller/AuthenticationController.java
+++ b/src/main/java/konkuk/ptal/controller/AuthenticationController.java
@@ -29,39 +29,39 @@ public class AuthenticationController {
 
     @PostMapping("/signin")
     public ResponseEntity<ApiResponse<AuthTokenResponse>> login(@Valid @RequestBody UserLoginRequest userLoginRequest) {
-        try{
+        try {
             AuthTokenResponse token = authService.login(userLoginRequest);
             return ResponseEntity.status(HttpStatus.OK)
                     .body(ApiResponse.success(ResponseCode.LOGIN_SUCCESS.getMessage(), token));
-        } catch (UnauthorizedException e){
-          return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                  .body(ApiResponse.fail(ErrorCode.USER_NOT_FOUND.getMessage() + "또는" + ErrorCode.PASSWORD_NOT_EQUAL.getMessage(), null));
+        } catch (UnauthorizedException e) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.fail(ErrorCode.USER_NOT_FOUND.getMessage() + "또는" + ErrorCode.PASSWORD_NOT_EQUAL.getMessage(), null));
         }
     }
 
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<AuthTokenResponse>> refresh(
             @Valid @RequestBody RefreshTokenRequest request) {
-        try{
+        try {
             AuthTokenResponse token = authService.refreshAccessToken(request);
 
             return ResponseEntity.status(HttpStatus.OK)
                     .body(ApiResponse.success(ResponseCode.TOKEN_REFRESH_SUCCESS.getMessage(), token));
-        } catch (UnauthorizedException e){
+        } catch (UnauthorizedException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(ApiResponse.fail(ErrorCode.INVALID_JWT.getMessage(), null));
         }
     }
 
     @PostMapping("/signout")
-    public ResponseEntity<ApiResponse<Void>> logout (
+    public ResponseEntity<ApiResponse<Void>> logout(
             @AuthenticationPrincipal UserDetails userDetails
-            ) {
-        try{
+    ) {
+        try {
             authService.logout(userDetails.getUsername());
             return ResponseEntity.status(HttpStatus.OK)
-                    .body(ApiResponse.success(ResponseCode.LOGOUT_SUCCESS.getMessage(),null));
-        }catch (UnauthorizedException e){
+                    .body(ApiResponse.success(ResponseCode.LOGOUT_SUCCESS.getMessage(), null));
+        } catch (UnauthorizedException e) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                     .body(ApiResponse.fail(ErrorCode.USER_NOT_FOUND.getMessage(), null));
         }

--- a/src/main/java/konkuk/ptal/controller/ReviewController.java
+++ b/src/main/java/konkuk/ptal/controller/ReviewController.java
@@ -1,21 +1,9 @@
 package konkuk.ptal.controller;
 
-import jakarta.validation.Valid;
-import konkuk.ptal.dto.api.ApiResponse;
-import konkuk.ptal.dto.api.ResponseCode;
-import konkuk.ptal.dto.request.CreateReviewSubmissionRequest;
-import konkuk.ptal.dto.request.UpdateReviewRequest;
-import konkuk.ptal.dto.response.CreateRevieweeResponse;
-import konkuk.ptal.dto.response.ReviewResponse;
-import konkuk.ptal.dto.response.CreateReviewerResponse;
-import konkuk.ptal.service.IReviewService; // TODO: Create this service interface
+import konkuk.ptal.service.IReviewService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDateTime;
-import java.util.List;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/reviews")

--- a/src/main/java/konkuk/ptal/controller/ReviewSubmissionController.java
+++ b/src/main/java/konkuk/ptal/controller/ReviewSubmissionController.java
@@ -1,8 +1,9 @@
 package konkuk.ptal.controller;
 
-import konkuk.ptal.service.IReviewSubmissionService; // TODO: Create this service interface
+import konkuk.ptal.service.IReviewSubmissionService;
 import lombok.RequiredArgsConstructor;
-        import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/review-submissions")

--- a/src/main/java/konkuk/ptal/controller/UserController.java
+++ b/src/main/java/konkuk/ptal/controller/UserController.java
@@ -2,26 +2,21 @@ package konkuk.ptal.controller;
 
 import jakarta.validation.Valid;
 import konkuk.ptal.dto.api.ApiResponse;
-import konkuk.ptal.dto.api.ErrorCode;
 import konkuk.ptal.dto.api.ResponseCode;
-// TODO: Define these DTOs
-// import konkuk.ptal.dto.request.UserUpdateRequestDto;
-// import konkuk.ptal.dto.response.UserResponseDto;
 import konkuk.ptal.dto.request.CreateRevieweeRequest;
 import konkuk.ptal.dto.request.CreateReviewerRequest;
 import konkuk.ptal.dto.response.CreateRevieweeResponse;
 import konkuk.ptal.dto.response.CreateReviewerResponse;
 import konkuk.ptal.entity.Reviewee;
 import konkuk.ptal.entity.Reviewer;
-import konkuk.ptal.entity.User; // Assuming you might return User or a UserResponseDto
-import konkuk.ptal.exception.BadRequestException;
-import konkuk.ptal.service.IUserService; // Assuming IUserService has general user methods
+import konkuk.ptal.service.IUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1") // Base path for user-specific operations
@@ -33,32 +28,24 @@ public class UserController {
     @PostMapping("/auth/signup/reviewee")
     public ResponseEntity<ApiResponse<CreateRevieweeResponse>> registerReviewee(
             @Valid @RequestBody CreateRevieweeRequest requestDto) {
-        try {
-            Reviewee reviewee = userService.registerReviewee(requestDto);
-            CreateRevieweeResponse responseDto = CreateRevieweeResponse.from(reviewee);
 
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(ApiResponse.success(ResponseCode.REVIEWEE_REGISTER_SUCCESS.getMessage(), responseDto));
-        } catch (BadRequestException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(ApiResponse.fail(ErrorCode.DUPLICATED_EMAIL.getMessage(), null));
-        }
+        Reviewee reviewee = userService.registerReviewee(requestDto);
+        CreateRevieweeResponse responseDto = CreateRevieweeResponse.from(reviewee);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(ResponseCode.REVIEWEE_REGISTER_SUCCESS.getMessage(), responseDto));
     }
 
 
     @PostMapping("/auth/signup/reviewer")
     public ResponseEntity<ApiResponse<CreateReviewerResponse>> registerReviewer(
             @Valid @RequestBody CreateReviewerRequest requestDto) {
-        try {
-            Reviewer reviewer = userService.registerReviewer(requestDto);
-            CreateReviewerResponse responseDto = CreateReviewerResponse.from(reviewer);
 
-            return ResponseEntity.status(HttpStatus.CREATED)
-                    .body(ApiResponse.success(ResponseCode.REVIEWER_REGISTER_SUCCESS.getMessage(), responseDto));
-        } catch (BadRequestException e) {
-            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                    .body(ApiResponse.fail(ErrorCode.DUPLICATED_EMAIL.getMessage(), null));
-        }
+        Reviewer reviewer = userService.registerReviewer(requestDto);
+        CreateReviewerResponse responseDto = CreateReviewerResponse.from(reviewer);
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(ResponseCode.REVIEWER_REGISTER_SUCCESS.getMessage(), responseDto));
     }
 
     // 아래 메서드들 openAPI에 누락돼있으나 필요해보임.

--- a/src/main/java/konkuk/ptal/controller/UserController.java
+++ b/src/main/java/konkuk/ptal/controller/UserController.java
@@ -5,10 +5,13 @@ import konkuk.ptal.dto.api.ApiResponse;
 import konkuk.ptal.dto.api.ResponseCode;
 import konkuk.ptal.dto.request.CreateRevieweeRequest;
 import konkuk.ptal.dto.request.CreateReviewerRequest;
+import konkuk.ptal.dto.request.UpdateUserRequest;
 import konkuk.ptal.dto.response.CreateRevieweeResponse;
 import konkuk.ptal.dto.response.CreateReviewerResponse;
+import konkuk.ptal.dto.response.ReadUserResponse;
 import konkuk.ptal.entity.Reviewee;
 import konkuk.ptal.entity.Reviewer;
+import konkuk.ptal.entity.User;
 import konkuk.ptal.service.IUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -86,6 +89,26 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
+    }
+
+    @GetMapping("/users/me")
+    public ResponseEntity<ApiResponse<ReadUserResponse>> getUser(@AuthenticationPrincipal Long userId) {
+        User user = userService.getUser(userId);
+        ReadUserResponse responseDto = ReadUserResponse.from(user);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
+    }
+
+    @PatchMapping("/users/me")
+    public ResponseEntity<ApiResponse<ReadUserResponse>> editUser(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody UpdateUserRequest request) {
+        User user = userService.updateUser(userId, request);
+        ReadUserResponse responseDto = ReadUserResponse.from(user);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(ResponseCode.DATA_UPDATE_SUCCESS.getMessage(), responseDto));
     }
 
 // 추가로 리뷰어목록도 누락돼있는거같은데 자세하게 함 봐야할듯..

--- a/src/main/java/konkuk/ptal/controller/UserController.java
+++ b/src/main/java/konkuk/ptal/controller/UserController.java
@@ -1,6 +1,7 @@
 package konkuk.ptal.controller;
 
 import jakarta.validation.Valid;
+import konkuk.ptal.domain.UserPrincipal;
 import konkuk.ptal.dto.api.ApiResponse;
 import konkuk.ptal.dto.api.ResponseCode;
 import konkuk.ptal.dto.request.CreateRevieweeRequest;
@@ -24,7 +25,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class UserController {
 
-    private final IUserService userService; // Or a dedicated IUserService for general user ops
+    private final IUserService userService;
 
     @PostMapping("/auth/signup/reviewee")
     public ResponseEntity<ApiResponse<CreateRevieweeResponse>> registerReviewee(
@@ -36,7 +37,6 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(ResponseCode.REVIEWEE_REGISTER_SUCCESS.getMessage(), responseDto));
     }
-
 
     @PostMapping("/auth/signup/reviewer")
     public ResponseEntity<ApiResponse<CreateReviewerResponse>> registerReviewer(
@@ -62,7 +62,8 @@ public class UserController {
     public ResponseEntity<ApiResponse<CreateRevieweeResponse>> updateReviewee(
             @PathVariable Long id,
             @Valid @RequestBody CreateRevieweeRequest requestDto,
-            @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getUserId();
         Reviewee updatedReviewee = userService.updateReviewee(id, requestDto, userId);
         CreateRevieweeResponse responseDto = CreateRevieweeResponse.from(updatedReviewee);
         return ResponseEntity
@@ -83,7 +84,8 @@ public class UserController {
     public ResponseEntity<ApiResponse<CreateReviewerResponse>> updateReviewer(
             @PathVariable Long id,
             @Valid @RequestBody CreateReviewerRequest requestDto,
-            @AuthenticationPrincipal Long userId) {
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getUserId();
         Reviewer updatedReviewer = userService.updateReviewer(id, requestDto, userId);
         CreateReviewerResponse responseDto = CreateReviewerResponse.from(updatedReviewer);
         return ResponseEntity
@@ -92,7 +94,8 @@ public class UserController {
     }
 
     @GetMapping("/users/me")
-    public ResponseEntity<ApiResponse<ReadUserResponse>> getUser(@AuthenticationPrincipal Long userId) {
+    public ResponseEntity<ApiResponse<ReadUserResponse>> getUser(@AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Long userId = userPrincipal.getUserId();
         User user = userService.getUser(userId);
         ReadUserResponse responseDto = ReadUserResponse.from(user);
         return ResponseEntity
@@ -102,8 +105,9 @@ public class UserController {
 
     @PatchMapping("/users/me")
     public ResponseEntity<ApiResponse<ReadUserResponse>> editUser(
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
             @Valid @RequestBody UpdateUserRequest request) {
+        Long userId = userPrincipal.getUserId();
         User user = userService.updateUser(userId, request);
         ReadUserResponse responseDto = ReadUserResponse.from(user);
         return ResponseEntity

--- a/src/main/java/konkuk/ptal/controller/UserController.java
+++ b/src/main/java/konkuk/ptal/controller/UserController.java
@@ -13,10 +13,8 @@ import konkuk.ptal.service.IUserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1") // Base path for user-specific operations
@@ -48,49 +46,47 @@ public class UserController {
                 .body(ApiResponse.success(ResponseCode.REVIEWER_REGISTER_SUCCESS.getMessage(), responseDto));
     }
 
-    // 아래 메서드들 openAPI에 누락돼있으나 필요해보임.
-//    @GetMapping("/reviewee/{id}")
-//    public ResponseEntity<ApiResponse<CreateRevieweeResponse>> getReviewee(@PathVariable Long id) {
-//        Reviewee reviewee = userService.getReviewee(id);
-//        CreateRevieweeResponse responseDto = CreateRevieweeResponse.from(reviewee);
-//        return ResponseEntity
-//                .status(HttpStatus.OK)
-//                .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
-//    }
-//
-//    @PutMapping("/reviewee/{id}")
-//    public ResponseEntity<ApiResponse<CreateRevieweeResponse>> updateReviewee(
-//            @PathVariable Long id,
-//            @Valid @RequestBody CreateRevieweeRequest requestDto,
-//            @AuthenticationPrincipal Long userId) {
-//        Reviewee updatedReviewee = userService.updateReviewee(id, requestDto, userId);
-//        CreateRevieweeResponse responseDto = CreateRevieweeResponse.from(updatedReviewee);
-//        return ResponseEntity
-//                .status(HttpStatus.OK)
-//                .body(ApiResponse.success(ResponseCode.OK.getMessage(), responseDto));
-//    }
+    @GetMapping("/reviewee/{id}")
+    public ResponseEntity<ApiResponse<CreateRevieweeResponse>> getReviewee(@PathVariable Long id) {
+        Reviewee reviewee = userService.getReviewee(id);
+        CreateRevieweeResponse responseDto = CreateRevieweeResponse.from(reviewee);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
+    }
 
-//
-//    @GetMapping("/reviewer/{id}")
-//    public ResponseEntity<ApiResponse<CreateReviewerResponse>> getReviewer(@PathVariable Long id) {
-//        Reviewer reviewer = userService.getReviewer(id);
-//        CreateReviewerResponse responseDto = CreateReviewerResponse.from(reviewer);
-//        return ResponseEntity
-//                .status(HttpStatus.OK)
-//                .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
-//    }
-//
-//    @PutMapping("/reviewer/{id}")
-//    public ResponseEntity<ApiResponse<CreateReviewerResponse>> updateReviewer(
-//            @PathVariable Long id,
-//            @Valid @RequestBody CreateReviewerRequest requestDto,
-//            @AuthenticationPrincipal Long userId) {
-//        Reviewer updatedReviewer = userService.updateReviewer(id, requestDto, userId);
-//        CreateReviewerResponse responseDto = CreateReviewerResponse.from(updatedReviewer);
-//        return ResponseEntity
-//                .status(HttpStatus.OK)
-//                .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
-//    }
+    @PutMapping("/reviewee/{id}")
+    public ResponseEntity<ApiResponse<CreateRevieweeResponse>> updateReviewee(
+            @PathVariable Long id,
+            @Valid @RequestBody CreateRevieweeRequest requestDto,
+            @AuthenticationPrincipal Long userId) {
+        Reviewee updatedReviewee = userService.updateReviewee(id, requestDto, userId);
+        CreateRevieweeResponse responseDto = CreateRevieweeResponse.from(updatedReviewee);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(ResponseCode.OK.getMessage(), responseDto));
+    }
+
+    @GetMapping("/reviewer/{id}")
+    public ResponseEntity<ApiResponse<CreateReviewerResponse>> getReviewer(@PathVariable Long id) {
+        Reviewer reviewer = userService.getReviewer(id);
+        CreateReviewerResponse responseDto = CreateReviewerResponse.from(reviewer);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
+    }
+
+    @PutMapping("/reviewer/{id}")
+    public ResponseEntity<ApiResponse<CreateReviewerResponse>> updateReviewer(
+            @PathVariable Long id,
+            @Valid @RequestBody CreateReviewerRequest requestDto,
+            @AuthenticationPrincipal Long userId) {
+        Reviewer updatedReviewer = userService.updateReviewer(id, requestDto, userId);
+        CreateReviewerResponse responseDto = CreateReviewerResponse.from(updatedReviewer);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
+    }
 
 // 추가로 리뷰어목록도 누락돼있는거같은데 자세하게 함 봐야할듯..
 // 문서에 있는 List쪽은 다 누락된거같음

--- a/src/main/java/konkuk/ptal/domain/UserPrincipal.java
+++ b/src/main/java/konkuk/ptal/domain/UserPrincipal.java
@@ -16,12 +16,14 @@ import java.util.stream.Collectors;
 public class UserPrincipal implements UserDetails {
     private static final long serialVersionUID = 1L;
 
+    private Long userId;  // userId 필드 추가
     private String email;  // memberId → email
     private String password;
     private List<String> roles;  // Set<String> → List<String> (roles는 실제 String 값으로 변환)
 
     public static UserPrincipal create(User user) {
         return new UserPrincipal(
+                user.getId(),  // userId 추가
                 user.getEmail(),  // 이메일로 변경
                 user.getPasswordHash(),  // 비밀번호는 passwordHash로 변경
                 List.of(user.getRole().name())  // Role enum을 String으로 변환하여 리스트에 담기

--- a/src/main/java/konkuk/ptal/dto/api/ResponseCode.java
+++ b/src/main/java/konkuk/ptal/dto/api/ResponseCode.java
@@ -10,7 +10,7 @@ public enum ResponseCode {
     LOGIN_SUCCESS("로그인 성공"),
     LOGOUT_SUCCESS("로그아웃 성공"),
     DATA_RETRIEVED("데이터 조회 성공"),
-
+    DATA_UPDATE_SUCCESS("데이터 수정 성공"),
     REVIEWER_REGISTER_SUCCESS("리뷰어 등록 성공"),
     REVIEWEE_REGISTER_SUCCESS("리뷰이 등록 성공"),
     REVIEW_CREATED("리뷰 생성 성공"),

--- a/src/main/java/konkuk/ptal/dto/request/CreateReviewRequest.java
+++ b/src/main/java/konkuk/ptal/dto/request/CreateReviewRequest.java
@@ -1,6 +1,5 @@
 package konkuk.ptal.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Data;

--- a/src/main/java/konkuk/ptal/dto/request/CreateReviewSubmissionRequest.java
+++ b/src/main/java/konkuk/ptal/dto/request/CreateReviewSubmissionRequest.java
@@ -1,7 +1,6 @@
 package konkuk.ptal.dto.request;
 
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/konkuk/ptal/dto/request/UpdateUserRequest.java
+++ b/src/main/java/konkuk/ptal/dto/request/UpdateUserRequest.java
@@ -1,23 +1,40 @@
 package konkuk.ptal.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import konkuk.ptal.dto.response.UserMinimalResponse;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Optional;
 
 @Data
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class UpdateUserRequest {
 
     @Email(message = "유효한 이메일 주소여야 합니다.")
-    private Optional<String> email;
+    private String email;
 
     @Size(min = 6, message = "비밀번호는 최소 6자 이상이어야 합니다.")
-    private Optional<String> password;
+    private String password;
 
-    private Optional<String> name;
+    private String name;
+
+    // Optional getter 메서드들
+    public Optional<String> getEmail() {
+        return Optional.ofNullable(email);
+    }
+
+    public Optional<String> getPassword() {
+        return Optional.ofNullable(password);
+    }
+
+    public Optional<String> getName() {
+        return Optional.ofNullable(name);
+    }
 }

--- a/src/main/java/konkuk/ptal/dto/request/UpdateUserRequest.java
+++ b/src/main/java/konkuk/ptal/dto/request/UpdateUserRequest.java
@@ -1,13 +1,23 @@
 package konkuk.ptal.dto.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import konkuk.ptal.dto.response.UserMinimalResponse;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.Optional;
+
 @Data
 @Builder
 public class UpdateUserRequest {
-    @NotBlank
-    String name;
+
+    @Email(message = "유효한 이메일 주소여야 합니다.")
+    private Optional<String> email;
+
+    @Size(min = 6, message = "비밀번호는 최소 6자 이상이어야 합니다.")
+    private Optional<String> password;
+
+    private Optional<String> name;
 }

--- a/src/main/java/konkuk/ptal/dto/response/BaseAuditResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/BaseAuditResponse.java
@@ -1,12 +1,9 @@
 package konkuk.ptal.dto.response;
 
-import konkuk.ptal.entity.Reviewee;
 import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Optional;
 
 @Data
 @Builder

--- a/src/main/java/konkuk/ptal/dto/response/BasePageResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/BasePageResponse.java
@@ -1,6 +1,5 @@
 package konkuk.ptal.dto.response;
 
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;

--- a/src/main/java/konkuk/ptal/dto/response/CreateRevieweeResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/CreateRevieweeResponse.java
@@ -5,7 +5,7 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional; // Optional 임포트 추가
+import java.util.Optional;
 
 @Getter
 @Setter

--- a/src/main/java/konkuk/ptal/dto/response/ListReviewSubmissionsResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ListReviewSubmissionsResponse.java
@@ -1,9 +1,11 @@
 package konkuk.ptal.dto.response;
+
 import konkuk.ptal.entity.ReviewRequest;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.springframework.data.domain.Page;
+
 import java.util.List;
 import java.util.stream.Collectors;
 

--- a/src/main/java/konkuk/ptal/dto/response/ListReviewersResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ListReviewersResponse.java
@@ -1,6 +1,5 @@
 package konkuk.ptal.dto.response;
 
-import konkuk.ptal.entity.Review;
 import konkuk.ptal.entity.Reviewer;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -13,7 +12,7 @@ import java.util.stream.Collectors;
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public class ListReviewersResponse extends BasePageResponse{
+public class ListReviewersResponse extends BasePageResponse {
     private List<ReadReviewerResponse> content;
 
 

--- a/src/main/java/konkuk/ptal/dto/response/ListReviewsResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ListReviewsResponse.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 @Data
 @NoArgsConstructor
 @EqualsAndHashCode(callSuper = true)
-public class ListReviewsResponse extends BasePageResponse{
+public class ListReviewsResponse extends BasePageResponse {
     private List<ReadReviewResponse> content;
 
 

--- a/src/main/java/konkuk/ptal/dto/response/ReadReviewResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadReviewResponse.java
@@ -1,6 +1,8 @@
 package konkuk.ptal.dto.response;
 
-import konkuk.ptal.entity.*;
+import konkuk.ptal.entity.Review;
+import konkuk.ptal.entity.Reviewee;
+import konkuk.ptal.entity.Reviewer;
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
@@ -4,7 +4,6 @@ import konkuk.ptal.domain.enums.ReviewRequestStatus;
 import konkuk.ptal.entity.ReviewRequest;
 import konkuk.ptal.entity.Reviewee;
 import konkuk.ptal.entity.Reviewer;
-import konkuk.ptal.entity.User;
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/konkuk/ptal/dto/response/ReadRevieweeResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadRevieweeResponse.java
@@ -1,7 +1,6 @@
 package konkuk.ptal.dto.response;
 
 import konkuk.ptal.entity.Reviewee;
-import konkuk.ptal.entity.User;
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/konkuk/ptal/dto/response/ReadReviewerResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadReviewerResponse.java
@@ -1,8 +1,6 @@
 package konkuk.ptal.dto.response;
 
-import konkuk.ptal.entity.Reviewee;
 import konkuk.ptal.entity.Reviewer;
-import konkuk.ptal.entity.User;
 import lombok.Builder;
 import lombok.Data;
 

--- a/src/main/java/konkuk/ptal/dto/response/ReadUserResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadUserResponse.java
@@ -1,7 +1,6 @@
 package konkuk.ptal.dto.response;
 
 import konkuk.ptal.domain.enums.Role;
-import konkuk.ptal.entity.Reviewer;
 import konkuk.ptal.entity.User;
 import lombok.Builder;
 import lombok.Data;

--- a/src/main/java/konkuk/ptal/dto/response/UserMinimalResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/UserMinimalResponse.java
@@ -1,11 +1,7 @@
 package konkuk.ptal.dto.response;
 
-import konkuk.ptal.entity.Reviewee;
 import lombok.Builder;
 import lombok.Data;
-
-import java.util.List;
-import java.util.Optional;
 
 @Data
 @Builder
@@ -14,7 +10,7 @@ public class UserMinimalResponse {
     String name;
     String email;
 
-    public static UserMinimalResponse from(Long id,String name, String email) {
+    public static UserMinimalResponse from(Long id, String name, String email) {
         return UserMinimalResponse.builder()
                 .id(id)
                 .name(name)

--- a/src/main/java/konkuk/ptal/entity/Reviewee.java
+++ b/src/main/java/konkuk/ptal/entity/Reviewee.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Entity
-@Table(name="reviewees")
+@Table(name = "reviewees")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -46,7 +46,7 @@ public class Reviewee {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public static Reviewee createReviewee(User user, CreateRevieweeRequest dto){
+    public static Reviewee createReviewee(User user, CreateRevieweeRequest dto) {
         return Reviewee.builder()
                 .user(user)
                 .preferences(dto.getPreferences())

--- a/src/main/java/konkuk/ptal/entity/Reviewer.java
+++ b/src/main/java/konkuk/ptal/entity/Reviewer.java
@@ -54,7 +54,7 @@ public class Reviewer {
         this.updatedAt = LocalDateTime.now();
     }
 
-    public static Reviewer createReviewer(User user, CreateReviewerRequest dto){
+    public static Reviewer createReviewer(User user, CreateReviewerRequest dto) {
         return Reviewer.builder()
                 .user(user)
                 .preferences(dto.getPreferences())

--- a/src/main/java/konkuk/ptal/entity/User.java
+++ b/src/main/java/konkuk/ptal/entity/User.java
@@ -5,8 +5,6 @@ import konkuk.ptal.domain.enums.Role;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.HashSet;
-import java.util.Set;
 
 @Entity
 @Getter
@@ -41,6 +39,7 @@ public class User {
 
     @Column(name = "refresh_token") // Refresh Token 저장 컬럼 추가
     private String refreshToken;
+
     @PrePersist
     protected void onCreate() {
         this.createdAt = LocalDateTime.now();
@@ -51,6 +50,7 @@ public class User {
     protected void onUpdate() {
         this.updatedAt = LocalDateTime.now();
     }
+
     public static User createUser(String email, String name, String passwordHash) {
         return User.builder()
                 .email(email)
@@ -63,6 +63,7 @@ public class User {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
     public void clearRefreshToken() {
         this.refreshToken = null;
     }

--- a/src/main/java/konkuk/ptal/exception/BaseException.java
+++ b/src/main/java/konkuk/ptal/exception/BaseException.java
@@ -17,4 +17,9 @@ public class BaseException extends RuntimeException {
     public ErrorCode getErrorCode() {
         return this.errorCode;
     }
+
+    @Override
+    public String getMessage() {
+        return this.errorCode.getMessage();
+    }
 }

--- a/src/main/java/konkuk/ptal/exception/BaseException.java
+++ b/src/main/java/konkuk/ptal/exception/BaseException.java
@@ -1,7 +1,6 @@
 package konkuk.ptal.exception;
 
 import konkuk.ptal.dto.api.ErrorCode;
-import konkuk.ptal.dto.api.ResponseCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/konkuk/ptal/exception/DuplicatedEmailException.java
+++ b/src/main/java/konkuk/ptal/exception/DuplicatedEmailException.java
@@ -1,0 +1,11 @@
+package konkuk.ptal.exception;
+
+import konkuk.ptal.dto.api.ErrorCode;
+
+public class DuplicatedEmailException extends BaseException {
+
+    public DuplicatedEmailException(ErrorCode code) {
+        super(code);
+    }
+
+}

--- a/src/main/java/konkuk/ptal/exception/GlobalExceptionHandler.java
+++ b/src/main/java/konkuk/ptal/exception/GlobalExceptionHandler.java
@@ -26,6 +26,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity.badRequest()
                 .body(ApiResponse.fail(errorMessage, null));
     }
+
+    @ExceptionHandler(DuplicatedEmailException.class)
+    public ResponseEntity<ApiResponse<?>> handleDuplicatedEmailException(DuplicatedEmailException ex) {
+        return buildResponse(ex, HttpStatus.BAD_REQUEST);
+    }
+
     @ExceptionHandler(BadRequestException.class)
     public ResponseEntity<ApiResponse<?>> handleBadRequestException(BadRequestException ex) {
         return buildResponse(ex, HttpStatus.BAD_REQUEST);
@@ -35,6 +41,7 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ApiResponse<?>> handleUnauthorizedException(UnauthorizedException ex) {
         return buildResponse(ex, HttpStatus.UNAUTHORIZED);
     }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ApiResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
         return buildResponse(ex, HttpStatus.BAD_REQUEST);

--- a/src/main/java/konkuk/ptal/exception/MethodArgumentNotValidException.java
+++ b/src/main/java/konkuk/ptal/exception/MethodArgumentNotValidException.java
@@ -2,7 +2,7 @@ package konkuk.ptal.exception;
 
 import konkuk.ptal.dto.api.ErrorCode;
 
-public class MethodArgumentNotValidException extends BaseException{
+public class MethodArgumentNotValidException extends BaseException {
     public MethodArgumentNotValidException(ErrorCode errorCode) {
         super(errorCode);
     }

--- a/src/main/java/konkuk/ptal/exception/UnauthorizedException.java
+++ b/src/main/java/konkuk/ptal/exception/UnauthorizedException.java
@@ -9,5 +9,4 @@ public class UnauthorizedException extends BaseException {
     }
 
 
-
 }

--- a/src/main/java/konkuk/ptal/service/AuthenticationServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/AuthenticationServiceImpl.java
@@ -10,7 +10,6 @@ import konkuk.ptal.dto.response.AuthTokenResponse;
 import konkuk.ptal.entity.User;
 import konkuk.ptal.exception.UnauthorizedException;
 import konkuk.ptal.repository.UserRepository;
-import konkuk.ptal.util.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -18,7 +17,6 @@ import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,8 +28,9 @@ public class AuthenticationServiceImpl implements IAuthenticationService {
     private final JwtTokenProvider jwtTokenProvider;
     private final AuthenticationManager authenticationManager;
     private final CustomUserDetailsService customUserDetailsService;
+
     public AuthTokenResponse login(UserLoginRequest userLoginRequest) {
-        try{
+        try {
             Authentication authentication = authenticationManager.authenticate(
                     new UsernamePasswordAuthenticationToken(
                             userLoginRequest.getEmail(),
@@ -52,7 +51,7 @@ public class AuthenticationServiceImpl implements IAuthenticationService {
                     tokenInfo.getAccessToken(),
                     tokenInfo.getRefreshToken()
             );
-        }catch (BadCredentialsException e){
+        } catch (BadCredentialsException e) {
             throw new UnauthorizedException(ErrorCode.PASSWORD_NOT_EQUAL);
         }
 

--- a/src/main/java/konkuk/ptal/service/CustomUserDetailsService.java
+++ b/src/main/java/konkuk/ptal/service/CustomUserDetailsService.java
@@ -1,4 +1,5 @@
 package konkuk.ptal.service;
+
 import konkuk.ptal.domain.UserPrincipal;
 import konkuk.ptal.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
+
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         return userRepository.findByEmail(email)

--- a/src/main/java/konkuk/ptal/service/IAuthenticationService.java
+++ b/src/main/java/konkuk/ptal/service/IAuthenticationService.java
@@ -3,11 +3,11 @@ package konkuk.ptal.service;
 import konkuk.ptal.dto.request.RefreshTokenRequest;
 import konkuk.ptal.dto.request.UserLoginRequest;
 import konkuk.ptal.dto.response.AuthTokenResponse;
-import org.springframework.security.core.userdetails.UserDetails;
 
 public interface IAuthenticationService {
-    public AuthTokenResponse login(UserLoginRequest dto);
-    public AuthTokenResponse refreshAccessToken(RefreshTokenRequest dto);
+    AuthTokenResponse login(UserLoginRequest dto);
 
-    public void logout(String email);
+    AuthTokenResponse refreshAccessToken(RefreshTokenRequest dto);
+
+    void logout(String email);
 }

--- a/src/main/java/konkuk/ptal/service/IUserService.java
+++ b/src/main/java/konkuk/ptal/service/IUserService.java
@@ -3,8 +3,10 @@ package konkuk.ptal.service;
 
 import konkuk.ptal.dto.request.CreateRevieweeRequest;
 import konkuk.ptal.dto.request.CreateReviewerRequest;
+import konkuk.ptal.dto.request.UpdateUserRequest;
 import konkuk.ptal.entity.Reviewee;
 import konkuk.ptal.entity.Reviewer;
+import konkuk.ptal.entity.User;
 
 public interface IUserService {
     Reviewer registerReviewer(CreateReviewerRequest dto);
@@ -18,4 +20,9 @@ public interface IUserService {
     Reviewee getReviewee(Long id);
 
     Reviewee updateReviewee(Long id, CreateRevieweeRequest dto, Long authenticatedUserId);
+
+    User getUser(Long id);
+
+    User updateUser(Long id, UpdateUserRequest dto);
+
 }

--- a/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
@@ -3,5 +3,5 @@ package konkuk.ptal.service;
 import org.springframework.stereotype.Service;
 
 @Service
-public class ReviewServiceImpl implements IReviewService{
+public class ReviewServiceImpl implements IReviewService {
 }

--- a/src/main/java/konkuk/ptal/service/UserServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/UserServiceImpl.java
@@ -8,6 +8,7 @@ import konkuk.ptal.entity.Reviewee;
 import konkuk.ptal.entity.Reviewer;
 import konkuk.ptal.entity.User;
 import konkuk.ptal.exception.BadRequestException;
+import konkuk.ptal.exception.DuplicatedEmailException;
 import konkuk.ptal.repository.RevieweeRepository;
 import konkuk.ptal.repository.ReviewerRepository;
 import konkuk.ptal.repository.UserRepository;
@@ -29,7 +30,7 @@ public class UserServiceImpl implements IUserService {
     @Override
     public Reviewer registerReviewer(CreateReviewerRequest dto) {
         if(userRepository.findByEmail(dto.getEmail()).isPresent()){
-            throw new BadRequestException(ErrorCode.DUPLICATED_EMAIL);
+            throw new DuplicatedEmailException(ErrorCode.DUPLICATED_EMAIL);
         }
         String hashedPassword = passwordEncoder.encode(dto.getPassword());
         User user = User.createUser(dto.getEmail(), dto.getName(), hashedPassword);
@@ -69,7 +70,7 @@ public class UserServiceImpl implements IUserService {
     @Override
     public Reviewee registerReviewee(CreateRevieweeRequest dto) {
         if (userRepository.findByEmail(dto.getEmail()).isPresent()) {
-            throw new BadRequestException(ErrorCode.DUPLICATED_EMAIL);
+            throw new DuplicatedEmailException(ErrorCode.DUPLICATED_EMAIL);
         }
         String hashedPassword = passwordEncoder.encode(dto.getPassword());
         User user = User.createUser(dto.getEmail(), dto.getName(), hashedPassword);

--- a/src/main/java/konkuk/ptal/util/PasswordEncoder.java
+++ b/src/main/java/konkuk/ptal/util/PasswordEncoder.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 public class PasswordEncoder implements org.springframework.security.crypto.password.PasswordEncoder {
 
     private final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
     @Override
     public String encode(CharSequence rawPassword) {
         return encoder.encode(rawPassword);

--- a/src/main/java/konkuk/ptal/util/StringListConverter.java
+++ b/src/main/java/konkuk/ptal/util/StringListConverter.java
@@ -2,7 +2,10 @@ package konkuk.ptal.util;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
-import java.util.*;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 @Converter
 public class StringListConverter implements AttributeConverter<List<String>, String> {

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -135,7 +135,7 @@ components:
         email: "reviewee@example.com"
         password: "password123"
         name: "김리뷰"
-        preferences: ["Java", "Spring Boot"]
+        preferences: [ "Java", "Spring Boot" ]
 
     CreateRevieweeResponse:
       type: object
@@ -155,7 +155,7 @@ components:
               description: "리뷰이의 관심 기술 분야 목록"
       example:
         id: 1
-        preferences: ["Java", "Spring Boot"]
+        preferences: [ "Java", "Spring Boot" ]
         createdAt: "2024-05-01T10:00:00Z"
         updatedAt: "2024-05-01T10:00:00Z"
 
@@ -195,9 +195,9 @@ components:
         email: "reviewer@example.com"
         password: "password456"
         name: "박리뷰"
-        preferences: ["Python", "Django"]
+        preferences: [ "Python", "Django" ]
         bio: "10년차 백엔드 개발자입니다."
-        tags: ["backend", "python", "api"]
+        tags: [ "backend", "python", "api" ]
 
     CreateReviewerResponse:
       type: object
@@ -225,9 +225,9 @@ components:
               description: "리뷰어 관련 태그 목록"
       example:
         id: 2
-        preferences: ["Python", "Django"]
+        preferences: [ "Python", "Django" ]
         bio: "10년차 백엔드 개발자입니다."
-        tags: ["backend", "python", "api"]
+        tags: [ "backend", "python", "api" ]
         createdAt: "2024-05-01T10:00:00Z"
         updatedAt: "2024-05-01T10:00:00Z"
 
@@ -251,7 +251,7 @@ components:
               description: "사용자 이름"
             role:
               type: string
-              enum: [USER, REVIEWER, REVIEWEE, ADMIN]
+              enum: [ USER, REVIEWER, REVIEWEE, ADMIN ]
               description: "사용자 권한 역할 (일반사용자, 리뷰어, 리뷰이, 관리자)"
       example:
         id: 101
@@ -281,7 +281,7 @@ components:
             type: string
           description: "새로 변경할 관심 기술 분야 목록"
       example:
-        preferences: ["JavaScript", "React"]
+        preferences: [ "JavaScript", "React" ]
 
     UpdateReviewerRequest:
       type: object
@@ -301,9 +301,9 @@ components:
             type: string
           description: "새로 변경할 태그 목록"
       example:
-        preferences: ["JavaScript", "Vue.js"]
+        preferences: [ "JavaScript", "Vue.js" ]
         bio: "프론트엔드 개발에 관심 많습니다."
-        tags: ["frontend", "vue"]
+        tags: [ "frontend", "vue" ]
 
     ReadRevieweeResponse:
       type: object
@@ -326,7 +326,7 @@ components:
               description: "리뷰이의 기본 사용자 정보"
       example:
         id: 1
-        preferences: ["Java", "Spring Boot"]
+        preferences: [ "Java", "Spring Boot" ]
         user:
           id: 101
           name: "김리뷰"
@@ -363,9 +363,9 @@ components:
               description: "리뷰어의 기본 사용자 정보"
       example:
         id: 2
-        preferences: ["Python", "Django"]
+        preferences: [ "Python", "Django" ]
         bio: "10년차 백엔드 개발자입니다."
-        tags: ["backend", "python", "api"]
+        tags: [ "backend", "python", "api" ]
         user:
           id: 102
           name: "박리뷰"
@@ -376,7 +376,7 @@ components:
     CreateReviewSubmissionRequest:
       type: object
       description: "새로운 리뷰 제출(요청) 생성 시 필요한 정보"
-      required: [reviewerId, gitUrl, requestDetails]
+      required: [ reviewerId, gitUrl, requestDetails ]
       properties:
         reviewerId:
           type: integer
@@ -420,13 +420,13 @@ components:
               description: "리뷰 요청 상세 설명"
             status:
               type: string
-              enum: [PENDING, CANCELED, REVIEWED]
+              enum: [ PENDING, CANCELED, REVIEWED ]
               description: "리뷰 제출 건의 현재 상태 (PENDING: 대기중, CANCELED: 취소됨, REVIEWED: 리뷰완료)"
       example:
         id: 1001
         reviewee:
           id: 1
-          preferences: ["Java", "Spring Boot"]
+          preferences: [ "Java", "Spring Boot" ]
           user:
             id: 101
             name: "김리뷰"
@@ -435,9 +435,9 @@ components:
           updatedAt: "2024-05-01T10:00:00Z"
         reviewer:
           id: 2
-          preferences: ["Python", "Django"]
+          preferences: [ "Python", "Django" ]
           bio: "10년차 백엔드 개발자입니다."
-          tags: ["backend", "python", "api"]
+          tags: [ "backend", "python", "api" ]
           user:
             id: 102
             name: "박리뷰"
@@ -453,7 +453,7 @@ components:
     CreateReviewRequest:
       type: object
       description: "리뷰어가 리뷰를 작성하여 제출할 때 필요한 정보"
-      required: [reviewSubmissionId, reviewContent]
+      required: [ reviewSubmissionId, reviewContent ]
       properties:
         reviewSubmissionId:
           type: integer
@@ -504,9 +504,9 @@ components:
         id: 201
         reviewer:
           id: 2
-          preferences: ["Python", "Django"]
+          preferences: [ "Python", "Django" ]
           bio: "10년차 백엔드 개발자입니다."
-          tags: ["backend", "python", "api"]
+          tags: [ "backend", "python", "api" ]
           user:
             id: 102
             name: "박리뷰"
@@ -515,7 +515,7 @@ components:
           updatedAt: "2024-05-01T10:00:00Z"
         reviewee:
           id: 1
-          preferences: ["Java", "Spring Boot"]
+          preferences: [ "Java", "Spring Boot" ]
           user:
             id: 101
             name: "김리뷰"
@@ -584,7 +584,7 @@ components:
           - id: 1001
             reviewee:
               id: 1
-              preferences: ["Java", "Spring Boot"]
+              preferences: [ "Java", "Spring Boot" ]
               user:
                 id: 101
                 name: "김리뷰"
@@ -593,9 +593,9 @@ components:
               updatedAt: "2024-05-01T10:00:00Z"
             reviewer:
               id: 2
-              preferences: ["Python", "Django"]
+              preferences: [ "Python", "Django" ]
               bio: "10년차 백엔드 개발자입니다."
-              tags: ["backend", "python", "api"]
+              tags: [ "backend", "python", "api" ]
               user:
                 id: 102
                 name: "박리뷰"
@@ -666,9 +666,9 @@ components:
         content:
           - id: 12
             user: { id: 102, name: "박전문", email: "reviewer1@example.com" }
-            preferences: ["Java", "Spring Boot"]
+            preferences: [ "Java", "Spring Boot" ]
             bio: "Java, Spring 전문가입니다."
-            tags: ["java", "spring", "backend"]
+            tags: [ "java", "spring", "backend" ]
             createdAt: "2024-03-10T11:00:00Z"
             updatedAt: "2024-05-01T17:30:00Z"
 
@@ -680,7 +680,7 @@ components:
       description: "JWT를 이용한 Bearer 토큰 인증 방식입니다. API 요청 시 `Authorization` 헤더에 `Bearer {JWT_TOKEN}` 형식으로 토큰을 포함해야 합니다."
 
 security:
-  - bearerAuth: []
+  - bearerAuth: [ ]
 
 paths:
   /auth/signup/reviewee:
@@ -700,7 +700,7 @@ paths:
               email: "reviewee@example.com"
               password: "password123"
               name: "김리뷰"
-              preferences: ["Java", "Spring Boot"]
+              preferences: [ "Java", "Spring Boot" ]
       responses:
         "201":
           description: "리뷰이 회원가입 및 프로필 생성 성공"
@@ -717,7 +717,7 @@ paths:
                 message: "리뷰이 가입 및 프로필 생성이 완료되었습니다."
                 data:
                   id: 1
-                  preferences: ["Java", "Spring Boot"]
+                  preferences: [ "Java", "Spring Boot" ]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-01T10:00:00Z"
         "400":
@@ -746,9 +746,9 @@ paths:
               email: "reviewer@example.com"
               password: "password456"
               name: "박리뷰"
-              preferences: ["Python", "Django"]
+              preferences: [ "Python", "Django" ]
               bio: "10년차 백엔드 개발자입니다."
-              tags: ["backend", "python", "api"]
+              tags: [ "backend", "python", "api" ]
       responses:
         "201":
           description: "리뷰어 회원가입 및 프로필 생성 성공"
@@ -765,9 +765,9 @@ paths:
                 message: "리뷰어 가입 및 프로필 생성이 완료되었습니다."
                 data:
                   id: 2
-                  preferences: ["Python", "Django"]
+                  preferences: [ "Python", "Django" ]
                   bio: "10년차 백엔드 개발자입니다."
-                  tags: ["backend", "python", "api"]
+                  tags: [ "backend", "python", "api" ]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-01T10:00:00Z"
         "400":
@@ -882,7 +882,7 @@ paths:
       summary: "사용자 로그아웃"
       description: "현재 인증된 사용자의 세션을 종료합니다. 서버는 필요시 (예: 리프레시 토큰) 관련 인증 토큰을 무효화할 수 있습니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         "200":
           description: "로그아웃 성공"
@@ -908,7 +908,7 @@ paths:
       summary: "내 정보 조회"
       description: "현재 인증된(로그인한) 사용자 본인의 상세 정보를 조회합니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       responses:
         "200":
           description: "사용자 정보 조회 성공"
@@ -944,7 +944,7 @@ paths:
       summary: "내 정보 수정"
       description: "현재 인증된 사용자 본인의 정보를 수정합니다. 주로 이름 변경 등에 사용됩니다. (리뷰이/리뷰어 프로필의 상세 정보는 각 프로필 수정 API를 사용하세요.)"
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       requestBody:
         required: true
         description: "수정할 사용자 정보 (예: 이름)"
@@ -999,7 +999,7 @@ paths:
       summary: "리뷰이 프로필 조회"
       description: "지정된 ID에 해당하는 리뷰이 프로필의 상세 정보를 조회합니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       parameters:
         - name: id
           in: path
@@ -1025,7 +1025,7 @@ paths:
                 message: "데이터 조회 성공"
                 data:
                   id: 1
-                  preferences: ["Java", "Spring Boot"]
+                  preferences: [ "Java", "Spring Boot" ]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-01T10:00:00Z"
         "400":
@@ -1050,7 +1050,7 @@ paths:
       summary: "리뷰이 프로필 수정"
       description: "지정된 ID에 해당하는 리뷰이 프로필의 정보를 수정합니다. 본인의 프로필만 수정할 수 있습니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       parameters:
         - name: id
           in: path
@@ -1071,7 +1071,7 @@ paths:
               email: "reviewee@example.com"
               password: "password123"
               name: "김리뷰"
-              preferences: ["JavaScript", "React"]
+              preferences: [ "JavaScript", "React" ]
       responses:
         "200":
           description: "리뷰이 프로필 수정 성공"
@@ -1088,7 +1088,7 @@ paths:
                 message: "OK"
                 data:
                   id: 1
-                  preferences: ["JavaScript", "React"]
+                  preferences: [ "JavaScript", "React" ]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-15T14:30:00Z"
         "400":
@@ -1122,7 +1122,7 @@ paths:
       summary: "리뷰어 프로필 조회"
       description: "지정된 ID에 해당하는 리뷰어 프로필의 상세 정보를 조회합니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       parameters:
         - name: id
           in: path
@@ -1148,9 +1148,9 @@ paths:
                 message: "데이터 조회 성공"
                 data:
                   id: 2
-                  preferences: ["Python", "Django"]
+                  preferences: [ "Python", "Django" ]
                   bio: "10년차 백엔드 개발자입니다."
-                  tags: ["backend", "python", "api"]
+                  tags: [ "backend", "python", "api" ]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-01T10:00:00Z"
         "400":
@@ -1175,7 +1175,7 @@ paths:
       summary: "리뷰어 프로필 수정"
       description: "지정된 ID에 해당하는 리뷰어 프로필의 정보를 수정합니다. 본인의 프로필만 수정할 수 있습니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       parameters:
         - name: id
           in: path
@@ -1196,9 +1196,9 @@ paths:
               email: "reviewer@example.com"
               password: "password456"
               name: "박리뷰"
-              preferences: ["JavaScript", "Vue.js"]
+              preferences: [ "JavaScript", "Vue.js" ]
               bio: "프론트엔드 개발에 관심 많습니다."
-              tags: ["frontend", "vue"]
+              tags: [ "frontend", "vue" ]
       responses:
         "200":
           description: "리뷰어 프로필 수정 성공"
@@ -1215,9 +1215,9 @@ paths:
                 message: "데이터 조회 성공"
                 data:
                   id: 2
-                  preferences: ["JavaScript", "Vue.js"]
+                  preferences: [ "JavaScript", "Vue.js" ]
                   bio: "프론트엔드 개발에 관심 많습니다."
-                  tags: ["frontend", "vue"]
+                  tags: [ "frontend", "vue" ]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-15T16:20:00Z"
         "400":
@@ -1251,7 +1251,7 @@ paths:
       summary: "새 리뷰 제출(요청) 생성"
       description: "리뷰이가 특정 리뷰어에게 코드 리뷰를 요청하는 새로운 제출 건을 생성합니다. 리뷰받을 Git 저장소 URL과 상세 요청 내용을 포함해야 합니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       requestBody:
         required: true
         description: "새로운 리뷰 제출에 필요한 정보"
@@ -1281,7 +1281,7 @@ paths:
                   id: 1001
                   reviewee:
                     id: 1
-                    preferences: ["Java", "Spring Boot"]
+                    preferences: [ "Java", "Spring Boot" ]
                     user:
                       id: 101
                       name: "김리뷰"
@@ -1290,9 +1290,9 @@ paths:
                     updatedAt: "2024-05-01T10:00:00Z"
                   reviewer:
                     id: 2
-                    preferences: ["Python", "Django"]
+                    preferences: [ "Python", "Django" ]
                     bio: "10년차 백엔드 개발자입니다."
-                    tags: ["backend", "python", "api"]
+                    tags: [ "backend", "python", "api" ]
                     user:
                       id: 102
                       name: "박리뷰"
@@ -1328,7 +1328,7 @@ paths:
       summary: "리뷰 제출(요청) 목록 조회"
       description: "리뷰 제출(요청) 목록을 조회합니다. 인증된 사용자를 기준으로 '자신이 보낸 요청', '자신이 받은 요청'(리뷰어의 경우), 또는 '모든 관련된 요청' 등으로 필터링할 수 있으며, 페이지네이션을 통해 결과를 제공합니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       parameters:
         - name: type
           in: query
@@ -1336,7 +1336,7 @@ paths:
           description: "조회할 제출 목록의 타입. `sent`: 내가 보낸 요청, `received`: 내가 받은 요청 (리뷰어만 해당), `all`: 나와 관련된 모든 요청. 기본값은 `all` 또는 사용자의 역할에 따라 적절히 설정될 수 있습니다."
           schema:
             type: string
-            enum: [sent, received, all]
+            enum: [ sent, received, all ]
             example: "sent"
         - name: page
           in: query
@@ -1380,7 +1380,7 @@ paths:
                     - id: 1001
                       reviewee:
                         id: 1
-                        preferences: ["Java", "Spring Boot"]
+                        preferences: [ "Java", "Spring Boot" ]
                         user:
                           id: 101
                           name: "김리뷰"
@@ -1389,9 +1389,9 @@ paths:
                         updatedAt: "2024-05-01T10:00:00Z"
                       reviewer:
                         id: 2
-                        preferences: ["Python", "Django"]
+                        preferences: [ "Python", "Django" ]
                         bio: "10년차 백엔드 개발자입니다."
-                        tags: ["backend", "python", "api"]
+                        tags: [ "backend", "python", "api" ]
                         user:
                           id: 102
                           name: "박리뷰"
@@ -1424,7 +1424,7 @@ paths:
       summary: "특정 리뷰 제출(요청) 상세 조회"
       description: "지정된 ID에 해당하는 리뷰 제출(요청) 건의 상세 정보를 조회합니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       parameters:
         - name: submissionId
           in: path
@@ -1481,7 +1481,7 @@ paths:
       summary: "리뷰 제출(요청) 취소"
       description: "리뷰이가 자신이 생성한 특정 리뷰 제출(요청) 건을 취소합니다. 이미 리뷰가 진행 중이거나 완료된 경우에는 취소가 불가능할 수 있습니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       parameters:
         - name: submissionId
           in: path
@@ -1548,7 +1548,7 @@ paths:
       summary: "특정 리뷰 상세 조회"
       description: "지정된 ID에 해당하는 단일 리뷰의 상세 정보를 조회합니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       parameters:
         - name: reviewId
           in: path
@@ -1604,7 +1604,7 @@ paths:
       summary: "리뷰 수정"
       description: "리뷰를 작성한 원본 리뷰어가 특정 리뷰의 내용을 수정합니다. 수정 기한이 있거나, 특정 조건 하에서만 수정이 가능할 수 있습니다."
       security:
-        - bearerAuth: []
+        - bearerAuth: [ ]
       parameters:
         - name: reviewId
           in: path

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -938,7 +938,7 @@ paths:
                 $ref: "#/components/schemas/ApiResponse"
               example:
                 message: "인증 토큰이 없거나 만료되었습니다."
-    put:
+    patch:
       tags:
         - 사용자 (User)
       summary: "내 정보 수정"

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -992,6 +992,258 @@ paths:
               example:
                 message: "인증 토큰이 없거나 만료되었습니다."
 
+  /reviewee/{id}:
+    get:
+      tags:
+        - 사용자 (User)
+      summary: "리뷰이 프로필 조회"
+      description: "지정된 ID에 해당하는 리뷰이 프로필의 상세 정보를 조회합니다."
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: "조회할 리뷰이 프로필의 고유 ID"
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      responses:
+        "200":
+          description: "리뷰이 프로필 조회 성공"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/CreateRevieweeResponse"
+              example:
+                message: "데이터 조회 성공"
+                data:
+                  id: 1
+                  preferences: ["Java", "Spring Boot"]
+                  createdAt: "2024-05-01T10:00:00Z"
+                  updatedAt: "2024-05-01T10:00:00Z"
+        "400":
+          description: "존재하지 않는 리뷰이 프로필 ID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+              example:
+                message: "사용자를 찾을 수 없습니다."
+        "401":
+          description: "인증되지 않은 사용자"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+              example:
+                message: "인증 토큰이 없거나 만료되었습니다."
+    put:
+      tags:
+        - 사용자 (User)
+      summary: "리뷰이 프로필 수정"
+      description: "지정된 ID에 해당하는 리뷰이 프로필의 정보를 수정합니다. 본인의 프로필만 수정할 수 있습니다."
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: "수정할 리뷰이 프로필의 고유 ID"
+          schema:
+            type: integer
+            format: int64
+            example: 1
+      requestBody:
+        required: true
+        description: "수정할 리뷰이 프로필 정보"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateRevieweeRequest"
+            example:
+              email: "reviewee@example.com"
+              password: "password123"
+              name: "김리뷰"
+              preferences: ["JavaScript", "React"]
+      responses:
+        "200":
+          description: "리뷰이 프로필 수정 성공"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/CreateRevieweeResponse"
+              example:
+                message: "OK"
+                data:
+                  id: 1
+                  preferences: ["JavaScript", "React"]
+                  createdAt: "2024-05-01T10:00:00Z"
+                  updatedAt: "2024-05-15T14:30:00Z"
+        "400":
+          description: "잘못된 요청 (존재하지 않는 리뷰이 프로필 ID 또는 본인의 프로필이 아닌 경우)"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+              examples:
+                user_not_found:
+                  summary: "리뷰이 프로필을 찾을 수 없는 경우"
+                  value:
+                    message: "사용자를 찾을 수 없습니다."
+                invalid_permission:
+                  summary: "본인의 프로필이 아닌 경우"
+                  value:
+                    message: "유효하지 않은 토큰입니다."
+        "401":
+          description: "인증되지 않은 사용자"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+              example:
+                message: "인증 토큰이 없거나 만료되었습니다."
+
+  /reviewer/{id}:
+    get:
+      tags:
+        - 사용자 (User)
+      summary: "리뷰어 프로필 조회"
+      description: "지정된 ID에 해당하는 리뷰어 프로필의 상세 정보를 조회합니다."
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: "조회할 리뷰어 프로필의 고유 ID"
+          schema:
+            type: integer
+            format: int64
+            example: 2
+      responses:
+        "200":
+          description: "리뷰어 프로필 조회 성공"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/CreateReviewerResponse"
+              example:
+                message: "데이터 조회 성공"
+                data:
+                  id: 2
+                  preferences: ["Python", "Django"]
+                  bio: "10년차 백엔드 개발자입니다."
+                  tags: ["backend", "python", "api"]
+                  createdAt: "2024-05-01T10:00:00Z"
+                  updatedAt: "2024-05-01T10:00:00Z"
+        "400":
+          description: "존재하지 않는 리뷰어 프로필 ID"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+              example:
+                message: "사용자를 찾을 수 없습니다."
+        "401":
+          description: "인증되지 않은 사용자"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+              example:
+                message: "인증 토큰이 없거나 만료되었습니다."
+    put:
+      tags:
+        - 사용자 (User)
+      summary: "리뷰어 프로필 수정"
+      description: "지정된 ID에 해당하는 리뷰어 프로필의 정보를 수정합니다. 본인의 프로필만 수정할 수 있습니다."
+      security:
+        - bearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          description: "수정할 리뷰어 프로필의 고유 ID"
+          schema:
+            type: integer
+            format: int64
+            example: 2
+      requestBody:
+        required: true
+        description: "수정할 리뷰어 프로필 정보"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateReviewerRequest"
+            example:
+              email: "reviewer@example.com"
+              password: "password456"
+              name: "박리뷰"
+              preferences: ["JavaScript", "Vue.js"]
+              bio: "프론트엔드 개발에 관심 많습니다."
+              tags: ["frontend", "vue"]
+      responses:
+        "200":
+          description: "리뷰어 프로필 수정 성공"
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: "#/components/schemas/ApiResponse"
+                  - type: object
+                    properties:
+                      data:
+                        $ref: "#/components/schemas/CreateReviewerResponse"
+              example:
+                message: "데이터 조회 성공"
+                data:
+                  id: 2
+                  preferences: ["JavaScript", "Vue.js"]
+                  bio: "프론트엔드 개발에 관심 많습니다."
+                  tags: ["frontend", "vue"]
+                  createdAt: "2024-05-01T10:00:00Z"
+                  updatedAt: "2024-05-15T16:20:00Z"
+        "400":
+          description: "잘못된 요청 (존재하지 않는 리뷰어 프로필 ID 또는 본인의 프로필이 아닌 경우)"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+              examples:
+                user_not_found:
+                  summary: "리뷰어 프로필을 찾을 수 없는 경우"
+                  value:
+                    message: "사용자를 찾을 수 없습니다."
+                invalid_permission:
+                  summary: "본인의 프로필이 아닌 경우"
+                  value:
+                    message: "유효하지 않은 토큰입니다."
+        "401":
+          description: "인증되지 않은 사용자"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+              example:
+                message: "인증 토큰이 없거나 만료되었습니다."
+
   /review-submissions/new:
     post:
       tags:

--- a/src/test/java/konkuk/ptal/config/TestSecurityConfig.java
+++ b/src/test/java/konkuk/ptal/config/TestSecurityConfig.java
@@ -15,12 +15,12 @@ public class TestSecurityConfig {
     @Bean
     public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
         http
-            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
-            .csrf(csrf -> csrf.disable())
-            .httpBasic(basic -> basic.disable())
-            .formLogin(form -> form.disable())
-            .sessionManagement(session -> session.disable());
-        
+                .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                .csrf(csrf -> csrf.disable())
+                .httpBasic(basic -> basic.disable())
+                .formLogin(form -> form.disable())
+                .sessionManagement(session -> session.disable());
+
         return http.build();
     }
 } 

--- a/src/test/java/konkuk/ptal/config/TestSecurityConfig.java
+++ b/src/test/java/konkuk/ptal/config/TestSecurityConfig.java
@@ -1,0 +1,26 @@
+package konkuk.ptal.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+@EnableWebSecurity
+@Profile("test")
+public class TestSecurityConfig {
+
+    @Bean
+    public SecurityFilterChain testFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+            .csrf(csrf -> csrf.disable())
+            .httpBasic(basic -> basic.disable())
+            .formLogin(form -> form.disable())
+            .sessionManagement(session -> session.disable());
+        
+        return http.build();
+    }
+} 

--- a/src/test/java/konkuk/ptal/controller/UserControllerTest.java
+++ b/src/test/java/konkuk/ptal/controller/UserControllerTest.java
@@ -21,17 +21,16 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.util.List;
 
 @WebMvcTest(UserController.class)
 @Import(TestSecurityConfig.class)
@@ -60,7 +59,7 @@ class UserControllerTest {
                 .name("Test User")
                 .passwordHash("hashedPassword")
                 .build();
-        
+
         // UserPrincipal 모킹
         testUserPrincipal = new UserPrincipal(
                 testUserId,
@@ -73,23 +72,23 @@ class UserControllerTest {
     private String createUpdateUserJson(String name, String email, String password) throws JsonProcessingException {
         StringBuilder json = new StringBuilder("{");
         boolean first = true;
-        
+
         if (name != null) {
             json.append("\"name\":\"").append(name).append("\"");
             first = false;
         }
-        
+
         if (email != null) {
             if (!first) json.append(",");
             json.append("\"email\":\"").append(email).append("\"");
             first = false;
         }
-        
+
         if (password != null) {
             if (!first) json.append(",");
             json.append("\"password\":\"").append(password).append("\"");
         }
-        
+
         json.append("}");
         return json.toString();
     }

--- a/src/test/java/konkuk/ptal/controller/UserControllerTest.java
+++ b/src/test/java/konkuk/ptal/controller/UserControllerTest.java
@@ -1,0 +1,236 @@
+package konkuk.ptal.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import konkuk.ptal.config.TestSecurityConfig;
+import konkuk.ptal.domain.UserPrincipal;
+import konkuk.ptal.dto.api.ErrorCode;
+import konkuk.ptal.dto.api.ResponseCode;
+import konkuk.ptal.dto.request.UpdateUserRequest;
+import konkuk.ptal.entity.User;
+import konkuk.ptal.exception.BadRequestException;
+import konkuk.ptal.service.IUserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+@WebMvcTest(UserController.class)
+@Import(TestSecurityConfig.class)
+@ActiveProfiles("test")
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private IUserService userService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private User testUser;
+    private Long testUserId;
+    private UserPrincipal testUserPrincipal;
+
+    @BeforeEach
+    void setUp() {
+        testUserId = 1L;
+        testUser = User.builder()
+                .id(testUserId)
+                .email("test@example.com")
+                .name("Test User")
+                .passwordHash("hashedPassword")
+                .build();
+        
+        // UserPrincipal 모킹
+        testUserPrincipal = new UserPrincipal(
+                testUserId,
+                "test@example.com",
+                "hashedPassword",
+                List.of("ROLE_USER")
+        );
+    }
+
+    private String createUpdateUserJson(String name, String email, String password) throws JsonProcessingException {
+        StringBuilder json = new StringBuilder("{");
+        boolean first = true;
+        
+        if (name != null) {
+            json.append("\"name\":\"").append(name).append("\"");
+            first = false;
+        }
+        
+        if (email != null) {
+            if (!first) json.append(",");
+            json.append("\"email\":\"").append(email).append("\"");
+            first = false;
+        }
+        
+        if (password != null) {
+            if (!first) json.append(",");
+            json.append("\"password\":\"").append(password).append("\"");
+        }
+        
+        json.append("}");
+        return json.toString();
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/users/me - 사용자 정보 조회 성공")
+    void getUserInfo_Success() throws Exception {
+        // given
+        when(userService.getUser(testUserId)).thenReturn(testUser);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/users/me")
+                        .with(user(testUserPrincipal))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(ResponseCode.DATA_RETRIEVED.getMessage()))
+                .andExpect(jsonPath("$.data.id").value(testUserId))
+                .andExpect(jsonPath("$.data.email").value("test@example.com"))
+                .andExpect(jsonPath("$.data.name").value("Test User"));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/v1/users/me - 사용자 정보 수정 성공")
+    void updateUserInfo_Success() throws Exception {
+        // given
+        User updatedUser = User.builder()
+                .id(testUserId)
+                .email("updated@example.com")
+                .name("Updated Name")
+                .passwordHash("hashedPassword")
+                .build();
+
+        when(userService.updateUser(eq(testUserId), any(UpdateUserRequest.class)))
+                .thenReturn(updatedUser);
+
+        String requestJson = createUpdateUserJson("Updated Name", "updated@example.com", null);
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/users/me")
+                        .with(user(testUserPrincipal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(ResponseCode.DATA_UPDATE_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.id").value(testUserId))
+                .andExpect(jsonPath("$.data.email").value("updated@example.com"))
+                .andExpect(jsonPath("$.data.name").value("Updated Name"));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/v1/users/me - 부분 업데이트 성공 (이름만 변경)")
+    void updateUserInfo_PartialUpdate_Success() throws Exception {
+        // given
+        User updatedUser = User.builder()
+                .id(testUserId)
+                .email("test@example.com")
+                .name("Updated Name Only")
+                .passwordHash("hashedPassword")
+                .build();
+
+        when(userService.updateUser(eq(testUserId), any(UpdateUserRequest.class)))
+                .thenReturn(updatedUser);
+
+        String requestJson = createUpdateUserJson("Updated Name Only", null, null);
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/users/me")
+                        .with(user(testUserPrincipal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value(ResponseCode.DATA_UPDATE_SUCCESS.getMessage()))
+                .andExpect(jsonPath("$.data.name").value("Updated Name Only"));
+    }
+
+    @Test
+    @DisplayName("PATCH /api/v1/users/me - 잘못된 요청 데이터")
+    void updateUserInfo_InvalidRequest() throws Exception {
+        // given
+        User updatedUser = User.builder()
+                .id(testUserId)
+                .email("test@example.com")
+                .name("Test User")
+                .passwordHash("hashedPassword")
+                .build();
+
+        when(userService.updateUser(eq(testUserId), any(UpdateUserRequest.class)))
+                .thenReturn(updatedUser);
+
+        String requestJson = "{}"; // 빈 객체
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/users/me")
+                        .with(user(testUserPrincipal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isOk()); // 빈 Optional 필드들로 인해 성공할 수 있음
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/users/me - 사용자를 찾을 수 없음")
+    void getUserInfo_UserNotFound() throws Exception {
+        // given
+        when(userService.getUser(testUserId))
+                .thenThrow(new BadRequestException(ErrorCode.USER_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/users/me")
+                        .with(user(testUserPrincipal))
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PATCH /api/v1/users/me - 사용자를 찾을 수 없음")
+    void updateUserInfo_UserNotFound() throws Exception {
+        // given
+        when(userService.updateUser(eq(testUserId), any(UpdateUserRequest.class)))
+                .thenThrow(new BadRequestException(ErrorCode.USER_NOT_FOUND));
+
+        String requestJson = createUpdateUserJson("Updated Name", null, null);
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/users/me")
+                        .with(user(testUserPrincipal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestJson))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("PATCH /api/v1/users/me - 잘못된 JSON 형식")
+    void updateUserInfo_InvalidJsonFormat() throws Exception {
+        // given
+        String invalidJson = "{ invalid json }";
+
+        // when & then
+        mockMvc.perform(patch("/api/v1/users/me")
+                        .with(user(testUserPrincipal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidJson))
+                .andExpect(status().is5xxServerError()); // JSON 파싱 오류는 500으로 처리됨
+    }
+}

--- a/src/test/java/konkuk/ptal/service/UserServiceImplTest.java
+++ b/src/test/java/konkuk/ptal/service/UserServiceImplTest.java
@@ -1,0 +1,322 @@
+package konkuk.ptal.service;
+
+import konkuk.ptal.dto.api.ErrorCode;
+import konkuk.ptal.dto.request.UpdateUserRequest;
+import konkuk.ptal.entity.User;
+import konkuk.ptal.exception.BadRequestException;
+import konkuk.ptal.repository.RevieweeRepository;
+import konkuk.ptal.repository.ReviewerRepository;
+import konkuk.ptal.repository.UserRepository;
+import konkuk.ptal.util.PasswordEncoder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private ReviewerRepository reviewerRepository;
+
+    @Mock
+    private RevieweeRepository revieweeRepository;
+
+    @InjectMocks
+    private UserServiceImpl userService;
+
+    private User testUser;
+    private Long testUserId;
+
+    @BeforeEach
+    void setUp() {
+        testUserId = 1L;
+        testUser = User.builder()
+                .id(testUserId)
+                .email("test@example.com")
+                .name("Test User")
+                .passwordHash("hashedPassword")
+                .build();
+    }
+
+    @Test
+    @DisplayName("getUser - 사용자 조회 성공")
+    void getUser_Success() {
+        // given
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
+
+        // when
+        User result = userService.getUser(testUserId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(testUserId);
+        assertThat(result.getEmail()).isEqualTo("test@example.com");
+        assertThat(result.getName()).isEqualTo("Test User");
+        
+        verify(userRepository).findById(testUserId);
+    }
+
+    @Test
+    @DisplayName("getUser - 사용자를 찾을 수 없는 경우 예외 발생")
+    void getUser_UserNotFound_ThrowException() {
+        // given
+        when(userRepository.findById(testUserId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUser(testUserId))
+                .isInstanceOf(BadRequestException.class);
+        
+        verify(userRepository).findById(testUserId);
+    }
+
+    @Test
+    @DisplayName("updateUser - 모든 필드 업데이트 성공")
+    void updateUser_AllFields_Success() {
+        // given
+        UpdateUserRequest updateRequest = UpdateUserRequest.builder()
+                .email("updated@example.com")
+                .name("Updated Name")
+                .password("newPassword")
+                .build();
+
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.encode("newPassword")).thenReturn("hashedNewPassword");
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // when
+        User result = userService.updateUser(testUserId, updateRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(userRepository).findById(testUserId);
+        verify(passwordEncoder).encode("newPassword");
+        verify(userRepository).save(testUser);
+    }
+
+    @Test
+    @DisplayName("updateUser - 이메일만 업데이트 성공")
+    void updateUser_EmailOnly_Success() {
+        // given
+        UpdateUserRequest updateRequest = UpdateUserRequest.builder()
+                .email("newemail@example.com")
+                .build();
+
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // when
+        User result = userService.updateUser(testUserId, updateRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(userRepository).findById(testUserId);
+        verify(userRepository).save(testUser);
+        verify(passwordEncoder, never()).encode(anyString());
+    }
+
+    @Test
+    @DisplayName("updateUser - 이름만 업데이트 성공")
+    void updateUser_NameOnly_Success() {
+        // given
+        UpdateUserRequest updateRequest = UpdateUserRequest.builder()
+                .name("New Name")
+                .build();
+
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // when
+        User result = userService.updateUser(testUserId, updateRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(userRepository).findById(testUserId);
+        verify(userRepository).save(testUser);
+        verify(passwordEncoder, never()).encode(anyString());
+    }
+
+    @Test
+    @DisplayName("updateUser - 비밀번호만 업데이트 성공")
+    void updateUser_PasswordOnly_Success() {
+        // given
+        UpdateUserRequest updateRequest = UpdateUserRequest.builder()
+                .password("newPassword123")
+                .build();
+
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.encode("newPassword123")).thenReturn("hashedNewPassword123");
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // when
+        User result = userService.updateUser(testUserId, updateRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(userRepository).findById(testUserId);
+        verify(passwordEncoder).encode("newPassword123");
+        verify(userRepository).save(testUser);
+    }
+
+    @Test
+    @DisplayName("updateUser - 빈 요청으로 업데이트 (변경사항 없음)")
+    void updateUser_EmptyRequest_Success() {
+        // given
+        UpdateUserRequest updateRequest = UpdateUserRequest.builder().build();
+
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+
+        // when
+        User result = userService.updateUser(testUserId, updateRequest);
+
+        // then
+        assertThat(result).isNotNull();
+        verify(userRepository).findById(testUserId);
+        verify(userRepository).save(testUser);
+        verify(passwordEncoder, never()).encode(anyString());
+    }
+
+    @Test
+    @DisplayName("updateUser - 사용자를 찾을 수 없는 경우 예외 발생")
+    void updateUser_UserNotFound_ThrowException() {
+        // given
+        UpdateUserRequest updateRequest = UpdateUserRequest.builder()
+                .name("New Name")
+                .build();
+
+        when(userRepository.findById(testUserId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUser(testUserId, updateRequest))
+                .isInstanceOf(BadRequestException.class);
+        
+        verify(userRepository).findById(testUserId);
+        verify(userRepository, never()).save(any(User.class));
+        verify(passwordEncoder, never()).encode(anyString());
+    }
+
+    @Test
+    @DisplayName("updateUser - null ID로 업데이트 시도")
+    void updateUser_NullUserId_ThrowException() {
+        // given
+        UpdateUserRequest updateRequest = UpdateUserRequest.builder()
+                .name("New Name")
+                .build();
+
+        when(userRepository.findById(null)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUser(null, updateRequest))
+                .isInstanceOf(BadRequestException.class);
+        
+        verify(userRepository).findById(null);
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("getUser - null ID로 조회 시도")
+    void getUser_NullUserId_ThrowException() {
+        // given
+        when(userRepository.findById(null)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUser(null))
+                .isInstanceOf(BadRequestException.class);
+        
+        verify(userRepository).findById(null);
+    }
+
+    @Test
+    @DisplayName("updateUser - 존재하지 않는 사용자 ID로 업데이트 시도")
+    void updateUser_NonExistentUserId_ThrowException() {
+        // given
+        Long nonExistentUserId = 99999L;
+        UpdateUserRequest updateRequest = UpdateUserRequest.builder()
+                .email("new@example.com")
+                .name("Updated Name")
+                .password("newPassword")
+                .build();
+
+        when(userRepository.findById(nonExistentUserId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUser(nonExistentUserId, updateRequest))
+                .isInstanceOf(BadRequestException.class);
+        
+        verify(userRepository).findById(nonExistentUserId);
+        verify(userRepository, never()).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("getUser - 존재하지 않는 사용자 ID로 조회 시도")
+    void getUser_NonExistentUserId_ThrowException() {
+        // given
+        Long nonExistentUserId = 99999L;
+        when(userRepository.findById(nonExistentUserId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getUser(nonExistentUserId))
+                .isInstanceOf(BadRequestException.class);
+        
+        verify(userRepository).findById(nonExistentUserId);
+    }
+
+    @Test
+    @DisplayName("updateUser - 데이터베이스 저장 중 예외 발생")
+    void updateUser_DatabaseSaveException() {
+        // given
+        UpdateUserRequest updateRequest = UpdateUserRequest.builder()
+                .name("Updated Name")
+                .password("newPassword")
+                .build();
+
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
+        when(userRepository.save(any(User.class))).thenThrow(new RuntimeException("Database error"));
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUser(testUserId, updateRequest))
+                .isInstanceOf(RuntimeException.class);
+        
+        verify(userRepository).findById(testUserId);
+        verify(userRepository).save(testUser);
+    }
+
+    @Test
+    @DisplayName("updateUser - 비밀번호 암호화 중 예외 발생")
+    void updateUser_PasswordEncodingException() {
+        // given
+        UpdateUserRequest updateRequest = UpdateUserRequest.builder()
+                .name("Updated Name")
+                .password("newPassword")
+                .build();
+
+        when(userRepository.findById(testUserId)).thenReturn(Optional.of(testUser));
+        when(passwordEncoder.encode("newPassword")).thenThrow(new RuntimeException("Encoding error"));
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateUser(testUserId, updateRequest))
+                .isInstanceOf(RuntimeException.class);
+        
+        verify(userRepository).findById(testUserId);
+        verify(passwordEncoder).encode("newPassword");
+        verify(userRepository, never()).save(any(User.class));
+    }
+}

--- a/src/test/java/konkuk/ptal/service/UserServiceImplTest.java
+++ b/src/test/java/konkuk/ptal/service/UserServiceImplTest.java
@@ -1,6 +1,5 @@
 package konkuk.ptal.service;
 
-import konkuk.ptal.dto.api.ErrorCode;
 import konkuk.ptal.dto.request.UpdateUserRequest;
 import konkuk.ptal.entity.User;
 import konkuk.ptal.exception.BadRequestException;
@@ -70,7 +69,7 @@ class UserServiceImplTest {
         assertThat(result.getId()).isEqualTo(testUserId);
         assertThat(result.getEmail()).isEqualTo("test@example.com");
         assertThat(result.getName()).isEqualTo("Test User");
-        
+
         verify(userRepository).findById(testUserId);
     }
 
@@ -83,7 +82,7 @@ class UserServiceImplTest {
         // when & then
         assertThatThrownBy(() -> userService.getUser(testUserId))
                 .isInstanceOf(BadRequestException.class);
-        
+
         verify(userRepository).findById(testUserId);
     }
 
@@ -207,7 +206,7 @@ class UserServiceImplTest {
         // when & then
         assertThatThrownBy(() -> userService.updateUser(testUserId, updateRequest))
                 .isInstanceOf(BadRequestException.class);
-        
+
         verify(userRepository).findById(testUserId);
         verify(userRepository, never()).save(any(User.class));
         verify(passwordEncoder, never()).encode(anyString());
@@ -226,7 +225,7 @@ class UserServiceImplTest {
         // when & then
         assertThatThrownBy(() -> userService.updateUser(null, updateRequest))
                 .isInstanceOf(BadRequestException.class);
-        
+
         verify(userRepository).findById(null);
         verify(userRepository, never()).save(any(User.class));
     }
@@ -240,7 +239,7 @@ class UserServiceImplTest {
         // when & then
         assertThatThrownBy(() -> userService.getUser(null))
                 .isInstanceOf(BadRequestException.class);
-        
+
         verify(userRepository).findById(null);
     }
 
@@ -260,7 +259,7 @@ class UserServiceImplTest {
         // when & then
         assertThatThrownBy(() -> userService.updateUser(nonExistentUserId, updateRequest))
                 .isInstanceOf(BadRequestException.class);
-        
+
         verify(userRepository).findById(nonExistentUserId);
         verify(userRepository, never()).save(any(User.class));
     }
@@ -275,7 +274,7 @@ class UserServiceImplTest {
         // when & then
         assertThatThrownBy(() -> userService.getUser(nonExistentUserId))
                 .isInstanceOf(BadRequestException.class);
-        
+
         verify(userRepository).findById(nonExistentUserId);
     }
 
@@ -294,7 +293,7 @@ class UserServiceImplTest {
         // when & then
         assertThatThrownBy(() -> userService.updateUser(testUserId, updateRequest))
                 .isInstanceOf(RuntimeException.class);
-        
+
         verify(userRepository).findById(testUserId);
         verify(userRepository).save(testUser);
     }
@@ -314,7 +313,7 @@ class UserServiceImplTest {
         // when & then
         assertThatThrownBy(() -> userService.updateUser(testUserId, updateRequest))
                 .isInstanceOf(RuntimeException.class);
-        
+
         verify(userRepository).findById(testUserId);
         verify(passwordEncoder).encode("newPassword");
         verify(userRepository, never()).save(any(User.class));

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,7 +1,7 @@
 spring:
   security:
     enabled: false
-  
+
 jwt:
   secret: dGVzdC1zZWNyZXQta2V5LWZvci10ZXN0aW5nLXB1cnBvc2VzLW9ubHk=  # test-secret-key-for-testing-purposes-only
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,11 @@
+spring:
+  security:
+    enabled: false
+  
+jwt:
+  secret: dGVzdC1zZWNyZXQta2V5LWZvci10ZXN0aW5nLXB1cnBvc2VzLW9ubHk=  # test-secret-key-for-testing-purposes-only
+
+logging:
+  level:
+    org.springframework.security: DEBUG
+    konkuk.ptal: DEBUG 


### PR DESCRIPTION
## 변경내용

- 기존 `UserController.java`에 있던 예외처리 (`BadRequestException`을 `DuplicatedEmailException`으로 별도 선언하고, 이를 `@ControllerAdvice`로 처리하도록 수정했습니다.
- 내 정보를 조회 (GET /users/me) 하고 수정 (PATCH /users/me) 하는 API를 구현했습니다.
- 구현 내용을 검사하는 유닛 테스트를 구현했습니다.

## 검토사항

- `userId`를 `UserPrincipal`에 포함시켜서 사용자 JWT에 USER ID가 포함되도록 했습니다.
  - Auth 정보에서 Long userId를 찾지 못했기 때문입니다.

## 제안사항

- `Reviewee` 와 `Reviewer` 수정에서 PUT이 아닌 PATCH로 수정하는 것은 어떤가요?