### PR TITLE
OAS 수정

### DIFF
--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: '3.0.0'
+openapi: "3.0.0"
 info:
   title: PTAL API
   version: v1
@@ -111,7 +111,7 @@ components:
         email: "reviewee@example.com"
         password: "password123"
         name: "김리뷰"
-        preferences: [ "Java", "Spring Boot" ]
+        preferences: ["Java", "Spring Boot"]
 
     CreateRevieweeResponse:
       type: object
@@ -131,7 +131,7 @@ components:
               description: "리뷰이의 관심 기술 분야 목록"
       example:
         id: 1
-        preferences: [ "Java", "Spring Boot" ]
+        preferences: ["Java", "Spring Boot"]
         createdAt: "2024-05-01T10:00:00Z"
         updatedAt: "2024-05-01T10:00:00Z"
 
@@ -171,9 +171,9 @@ components:
         email: "reviewer@example.com"
         password: "password456"
         name: "박리뷰"
-        preferences: [ "Python", "Django" ]
+        preferences: ["Python", "Django"]
         bio: "10년차 백엔드 개발자입니다."
-        tags: [ "backend", "python", "api" ]
+        tags: ["backend", "python", "api"]
 
     CreateReviewerResponse:
       type: object
@@ -201,9 +201,9 @@ components:
               description: "리뷰어 관련 태그 목록"
       example:
         id: 2
-        preferences: [ "Python", "Django" ]
+        preferences: ["Python", "Django"]
         bio: "10년차 백엔드 개발자입니다."
-        tags: [ "backend", "python", "api" ]
+        tags: ["backend", "python", "api"]
         createdAt: "2024-05-01T10:00:00Z"
         updatedAt: "2024-05-01T10:00:00Z"
 
@@ -227,7 +227,7 @@ components:
               description: "사용자 이름"
             role:
               type: string
-              enum: [ USER, REVIEWER, REVIEWEE, ADMIN ]
+              enum: [USER, REVIEWER, REVIEWEE, ADMIN]
               description: "사용자 권한 역할 (일반사용자, 리뷰어, 리뷰이, 관리자)"
       example:
         id: 101
@@ -257,7 +257,7 @@ components:
             type: string
           description: "새로 변경할 관심 기술 분야 목록"
       example:
-        preferences: [ "JavaScript", "React" ]
+        preferences: ["JavaScript", "React"]
 
     UpdateReviewerRequest:
       type: object
@@ -277,9 +277,9 @@ components:
             type: string
           description: "새로 변경할 태그 목록"
       example:
-        preferences: [ "JavaScript", "Vue.js" ]
+        preferences: ["JavaScript", "Vue.js"]
         bio: "프론트엔드 개발에 관심 많습니다."
-        tags: [ "frontend", "vue" ]
+        tags: ["frontend", "vue"]
 
     ReadRevieweeResponse:
       type: object
@@ -302,7 +302,7 @@ components:
               description: "리뷰이의 기본 사용자 정보"
       example:
         id: 1
-        preferences: [ "Java", "Spring Boot" ]
+        preferences: ["Java", "Spring Boot"]
         user:
           id: 101
           name: "김리뷰"
@@ -339,9 +339,9 @@ components:
               description: "리뷰어의 기본 사용자 정보"
       example:
         id: 2
-        preferences: [ "Python", "Django" ]
+        preferences: ["Python", "Django"]
         bio: "10년차 백엔드 개발자입니다."
-        tags: [ "backend", "python", "api" ]
+        tags: ["backend", "python", "api"]
         user:
           id: 102
           name: "박리뷰"
@@ -352,7 +352,7 @@ components:
     CreateReviewSubmissionRequest:
       type: object
       description: "새로운 리뷰 제출(요청) 생성 시 필요한 정보"
-      required: [ reviewerId, gitUrl, requestDetails ]
+      required: [reviewerId, gitUrl, requestDetails]
       properties:
         reviewerId:
           type: integer
@@ -396,13 +396,13 @@ components:
               description: "리뷰 요청 상세 설명"
             status:
               type: string
-              enum: [ PENDING, CANCELED, REVIEWED ]
+              enum: [PENDING, CANCELED, REVIEWED]
               description: "리뷰 제출 건의 현재 상태 (PENDING: 대기중, CANCELED: 취소됨, REVIEWED: 리뷰완료)"
       example:
         id: 1001
         reviewee:
           id: 1
-          preferences: [ "Java", "Spring Boot" ]
+          preferences: ["Java", "Spring Boot"]
           user:
             id: 101
             name: "김리뷰"
@@ -411,9 +411,9 @@ components:
           updatedAt: "2024-05-01T10:00:00Z"
         reviewer:
           id: 2
-          preferences: [ "Python", "Django" ]
+          preferences: ["Python", "Django"]
           bio: "10년차 백엔드 개발자입니다."
-          tags: [ "backend", "python", "api" ]
+          tags: ["backend", "python", "api"]
           user:
             id: 102
             name: "박리뷰"
@@ -429,7 +429,7 @@ components:
     CreateReviewRequest:
       type: object
       description: "리뷰어가 리뷰를 작성하여 제출할 때 필요한 정보"
-      required: [ reviewSubmissionId, reviewContent ]
+      required: [reviewSubmissionId, reviewContent]
       properties:
         reviewSubmissionId:
           type: integer
@@ -456,52 +456,40 @@ components:
       type: object
       description: "단일 리뷰 조회 응답 정보"
       allOf:
-        - $ref: "#/components/schemas/BaseAuditResponse"
+        - $ref: "#/components/schemas/ReadReviewSubmissionResponse"
         - type: object
           properties:
-            id:
-              type: integer
-              format: int64
-              description: "리뷰의 고유 ID"
-            reviewer:
-              $ref: "#/components/schemas/ReadReviewerResponse"
-              description: "리뷰를 작성한 리뷰어의 프로필 정보"
-            reviewee:
-              $ref: "#/components/schemas/ReadRevieweeResponse"
-              description: "리뷰를 받은 리뷰이의 프로필 정보"
-            reviewSubmissionId:
-              type: integer
-              format: int64
-              description: "해당 리뷰가 속한 리뷰 제출(요청) 건의 고유 ID"
             reviewContent:
               type: string
               description: "리뷰 내용"
       example:
-        id: 201
-        reviewer:
-          id: 2
-          preferences: [ "Python", "Django" ]
-          bio: "10년차 백엔드 개발자입니다."
-          tags: [ "backend", "python", "api" ]
-          user:
-            id: 102
-            name: "박리뷰"
-            email: "reviewer@example.com"
-          createdAt: "2024-05-01T10:00:00Z"
-          updatedAt: "2024-05-01T10:00:00Z"
+        id: 1001
         reviewee:
           id: 1
-          preferences: [ "Java", "Spring Boot" ]
+          preferences: ["Java", "Spring Boot"]
           user:
             id: 101
             name: "김리뷰"
             email: "reviewee@example.com"
           createdAt: "2024-05-01T10:00:00Z"
           updatedAt: "2024-05-01T10:00:00Z"
-        reviewSubmissionId: 1001
-        reviewContent: "코드 잘 봤습니다. UserDTO 네이밍을 UserRequestDTO 등으로 변경하는 것이 좋겠습니다."
+        reviewer:
+          id: 2
+          preferences: ["Python", "Django"]
+          bio: "10년차 백엔드 개발자입니다."
+          tags: ["backend", "python", "api"]
+          user:
+            id: 102
+            name: "박리뷰"
+            email: "reviewer@example.com"
+          createdAt: "2024-05-01T10:00:00Z"
+          updatedAt: "2024-05-01T10:00:00Z"
+        gitUrl: "https://github.com/user/project/pull/1"
+        requestDetails: "회원가입 기능 구현 관련 코드 리뷰 부탁드립니다."
+        status: "PENDING"
         createdAt: "2024-05-16T10:00:00Z"
         updatedAt: "2024-05-16T10:00:00Z"
+        reviewContent: "코드 잘 봤습니다. UserDTO 네이밍을 UserRequestDTO 등으로 변경하는 것이 좋겠습니다."
 
     BasePageResponse:
       type: object
@@ -560,7 +548,7 @@ components:
           - id: 1001
             reviewee:
               id: 1
-              preferences: [ "Java", "Spring Boot" ]
+              preferences: ["Java", "Spring Boot"]
               user:
                 id: 101
                 name: "김리뷰"
@@ -569,9 +557,9 @@ components:
               updatedAt: "2024-05-01T10:00:00Z"
             reviewer:
               id: 2
-              preferences: [ "Python", "Django" ]
+              preferences: ["Python", "Django"]
               bio: "10년차 백엔드 개발자입니다."
-              tags: [ "backend", "python", "api" ]
+              tags: ["backend", "python", "api"]
               user:
                 id: 102
                 name: "박리뷰"
@@ -609,56 +597,60 @@ components:
         last: true
         numberOfElements: 2
         content:
-          - id: 201
-            reviewer:
-              id: 2
-              preferences: [ "Python", "Django" ]
-              bio: "10년차 백엔드 개발자입니다."
-              tags: [ "backend", "python", "api" ]
-              user:
-                id: 102
-                name: "박리뷰"
-                email: "reviewer@example.com"
-              createdAt: "2024-05-01T10:00:00Z"
-              updatedAt: "2024-05-01T10:00:00Z"
+          - id: 1001
             reviewee:
               id: 1
-              preferences: [ "Java", "Spring Boot" ]
+              preferences: ["Java", "Spring Boot"]
               user:
                 id: 101
                 name: "김리뷰"
                 email: "reviewee@example.com"
               createdAt: "2024-05-01T10:00:00Z"
               updatedAt: "2024-05-01T10:00:00Z"
-            reviewSubmissionId: 1001
-            reviewContent: "좋은 코드입니다."
+            reviewer:
+              id: 2
+              preferences: ["Python", "Django"]
+              bio: "10년차 백엔드 개발자입니다."
+              tags: ["backend", "python", "api"]
+              user:
+                id: 102
+                name: "박리뷰"
+                email: "reviewer@example.com"
+              createdAt: "2024-05-01T10:00:00Z"
+              updatedAt: "2024-05-01T10:00:00Z"
+            gitUrl: "https://github.com/user/project/pull/1"
+            requestDetails: "회원가입 기능 구현 관련 코드 리뷰 부탁드립니다."
+            status: "PENDING"
             createdAt: "2024-05-16T10:00:00Z"
             updatedAt: "2024-05-16T10:00:00Z"
-          - id: 202
-            reviewer:
-              id: 3
-              preferences: [ "JavaScript", "React" ]
-              bio: "5년차 프론트엔드 개발자입니다."
-              tags: [ "frontend", "javascript", "react" ]
-              user:
-                id: 103
-                name: "최리뷰"
-                email: "reviewer2@example.com"
-              createdAt: "2024-05-02T10:00:00Z"
-              updatedAt: "2024-05-02T10:00:00Z"
+            reviewContent: "코드 잘 봤습니다. UserDTO 네이밍을 UserRequestDTO 등으로 변경하는 것이 좋겠습니다."
+          - id: 1002
             reviewee:
               id: 4
-              preferences: [ "Python", "Flask" ]
+              preferences: ["Python", "Flask"]
               user:
                 id: 104
                 name: "이리뷰이"
                 email: "reviewee2@example.com"
               createdAt: "2024-05-03T10:00:00Z"
               updatedAt: "2024-05-03T10:00:00Z"
-            reviewSubmissionId: 1002
-            reviewContent: "몇 가지 개선점이 보입니다."
+            reviewer:
+              id: 3
+              preferences: ["JavaScript", "React"]
+              bio: "5년차 프론트엔드 개발자입니다."
+              tags: ["frontend", "javascript", "react"]
+              user:
+                id: 103
+                name: "최리뷰"
+                email: "reviewer2@example.com"
+              createdAt: "2024-05-02T10:00:00Z"
+              updatedAt: "2024-05-02T10:00:00Z"
+            gitUrl: "https://github.com/user/project/pull/2"
+            requestDetails: "몇 가지 개선점이 보입니다."
+            status: "REVIEWED"
             createdAt: "2024-05-17T11:00:00Z"
             updatedAt: "2024-05-17T11:00:00Z"
+            reviewContent: "몇 가지 개선점이 보입니다."
 
     ListReviewersResponse:
       description: "리뷰어 목록 조회 응답. 페이지네이션 정보를 포함합니다."
@@ -682,9 +674,9 @@ components:
         content:
           - id: 12
             user: { id: 102, name: "박전문", email: "reviewer1@example.com" }
-            preferences: [ "Java", "Spring Boot" ]
+            preferences: ["Java", "Spring Boot"]
             bio: "Java, Spring 전문가입니다."
-            tags: [ "java", "spring", "backend" ]
+            tags: ["java", "spring", "backend"]
             createdAt: "2024-03-10T11:00:00Z"
             updatedAt: "2024-05-01T17:30:00Z"
 
@@ -696,7 +688,7 @@ components:
       description: "JWT를 이용한 Bearer 토큰 인증 방식입니다. API 요청 시 `Authorization` 헤더에 `Bearer {JWT_TOKEN}` 형식으로 토큰을 포함해야 합니다."
 
 security:
-  - bearerAuth: [ ]
+  - bearerAuth: []
 
 paths:
   /auth/signup/reviewee:
@@ -716,7 +708,7 @@ paths:
               email: "reviewee@example.com"
               password: "password123"
               name: "김리뷰"
-              preferences: [ "Java", "Spring Boot" ]
+              preferences: ["Java", "Spring Boot"]
       responses:
         "201":
           description: "리뷰이 회원가입 및 프로필 생성 성공"
@@ -733,7 +725,7 @@ paths:
                 message: "리뷰이 가입 및 프로필 생성이 완료되었습니다."
                 data:
                   id: 1
-                  preferences: [ "Java", "Spring Boot" ]
+                  preferences: ["Java", "Spring Boot"]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-01T10:00:00Z"
         "400":
@@ -762,9 +754,9 @@ paths:
               email: "reviewer@example.com"
               password: "password456"
               name: "박리뷰"
-              preferences: [ "Python", "Django" ]
+              preferences: ["Python", "Django"]
               bio: "10년차 백엔드 개발자입니다."
-              tags: [ "backend", "python", "api" ]
+              tags: ["backend", "python", "api"]
       responses:
         "201":
           description: "리뷰어 회원가입 및 프로필 생성 성공"
@@ -781,9 +773,9 @@ paths:
                 message: "리뷰어 가입 및 프로필 생성이 완료되었습니다."
                 data:
                   id: 2
-                  preferences: [ "Python", "Django" ]
+                  preferences: ["Python", "Django"]
                   bio: "10년차 백엔드 개발자입니다."
-                  tags: [ "backend", "python", "api" ]
+                  tags: ["backend", "python", "api"]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-01T10:00:00Z"
         "400":
@@ -801,6 +793,7 @@ paths:
         - 인증 (Authentication)
       summary: "사용자 로그인"
       description: "등록된 사용자가 이메일과 비밀번호를 사용하여 시스템에 로그인하고, 성공 시 JWT 인증 토큰 (액세스 토큰, 리프레시 토큰)을 발급받습니다."
+      security: []
       requestBody:
         required: true
         description: "로그인에 필요한 사용자 이메일과 비밀번호"
@@ -898,7 +891,7 @@ paths:
       summary: "사용자 로그아웃"
       description: "현재 인증된 사용자의 세션을 종료합니다. 서버는 필요시 (예: 리프레시 토큰) 관련 인증 토큰을 무효화할 수 있습니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       responses:
         "200":
           description: "로그아웃 성공"
@@ -924,7 +917,7 @@ paths:
       summary: "내 정보 조회"
       description: "현재 인증된(로그인한) 사용자 본인의 상세 정보를 조회합니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       responses:
         "200":
           description: "사용자 정보 조회 성공"
@@ -960,7 +953,7 @@ paths:
       summary: "내 정보 수정"
       description: "현재 인증된 사용자 본인의 정보를 수정합니다. 주로 이름 변경 등에 사용됩니다. (리뷰이/리뷰어 프로필의 상세 정보는 각 프로필 수정 API를 사용하세요.)"
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       requestBody:
         required: true
         description: "수정할 사용자 정보 (예: 이름)"
@@ -1015,7 +1008,7 @@ paths:
       summary: "리뷰이 프로필 조회"
       description: "지정된 ID에 해당하는 리뷰이 프로필의 상세 정보를 조회합니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
@@ -1041,7 +1034,7 @@ paths:
                 message: "데이터 조회 성공"
                 data:
                   id: 1
-                  preferences: [ "Java", "Spring Boot" ]
+                  preferences: ["Java", "Spring Boot"]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-01T10:00:00Z"
         "400":
@@ -1066,7 +1059,7 @@ paths:
       summary: "리뷰이 프로필 수정"
       description: "지정된 ID에 해당하는 리뷰이 프로필의 정보를 수정합니다. 본인의 프로필만 수정할 수 있습니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
@@ -1084,7 +1077,7 @@ paths:
             schema:
               $ref: "#/components/schemas/UpdateRevieweeRequest"
             example:
-              preferences: [ "JavaScript", "React" ]
+              preferences: ["JavaScript", "React"]
       responses:
         "200":
           description: "리뷰이 프로필 수정 성공"
@@ -1101,7 +1094,7 @@ paths:
                 message: "OK"
                 data:
                   id: 1
-                  preferences: [ "JavaScript", "React" ]
+                  preferences: ["JavaScript", "React"]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-15T14:30:00Z"
         "400":
@@ -1135,7 +1128,7 @@ paths:
       summary: "리뷰어 프로필 조회"
       description: "지정된 ID에 해당하는 리뷰어 프로필의 상세 정보를 조회합니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
@@ -1161,9 +1154,9 @@ paths:
                 message: "데이터 조회 성공"
                 data:
                   id: 2
-                  preferences: [ "Python", "Django" ]
+                  preferences: ["Python", "Django"]
                   bio: "10년차 백엔드 개발자입니다."
-                  tags: [ "backend", "python", "api" ]
+                  tags: ["backend", "python", "api"]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-01T10:00:00Z"
         "400":
@@ -1188,7 +1181,7 @@ paths:
       summary: "리뷰어 프로필 수정"
       description: "지정된 ID에 해당하는 리뷰어 프로필의 정보를 수정합니다. 본인의 프로필만 수정할 수 있습니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: id
           in: path
@@ -1206,9 +1199,9 @@ paths:
             schema:
               $ref: "#/components/schemas/UpdateReviewerRequest"
             example:
-              preferences: [ "JavaScript", "Vue.js" ]
+              preferences: ["JavaScript", "Vue.js"]
               bio: "프론트엔드 개발에 관심 많습니다."
-              tags: [ "frontend", "vue" ]
+              tags: ["frontend", "vue"]
       responses:
         "200":
           description: "리뷰어 프로필 수정 성공"
@@ -1225,9 +1218,9 @@ paths:
                 message: "데이터 조회 성공"
                 data:
                   id: 2
-                  preferences: [ "JavaScript", "Vue.js" ]
+                  preferences: ["JavaScript", "Vue.js"]
                   bio: "프론트엔드 개발에 관심 많습니다."
-                  tags: [ "frontend", "vue" ]
+                  tags: ["frontend", "vue"]
                   createdAt: "2024-05-01T10:00:00Z"
                   updatedAt: "2024-05-15T16:20:00Z"
         "400":
@@ -1261,7 +1254,7 @@ paths:
       summary: "새 리뷰 제출(요청) 생성"
       description: "리뷰이가 특정 리뷰어에게 코드 리뷰를 요청하는 새로운 제출 건을 생성합니다. 리뷰받을 Git 저장소 URL과 상세 요청 내용을 포함해야 합니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       requestBody:
         required: true
         description: "새로운 리뷰 제출에 필요한 정보"
@@ -1291,7 +1284,7 @@ paths:
                   id: 1001
                   reviewee:
                     id: 1
-                    preferences: [ "Java", "Spring Boot" ]
+                    preferences: ["Java", "Spring Boot"]
                     user:
                       id: 101
                       name: "김리뷰"
@@ -1300,9 +1293,9 @@ paths:
                     updatedAt: "2024-05-01T10:00:00Z"
                   reviewer:
                     id: 2
-                    preferences: [ "Python", "Django" ]
+                    preferences: ["Python", "Django"]
                     bio: "10년차 백엔드 개발자입니다."
-                    tags: [ "backend", "python", "api" ]
+                    tags: ["backend", "python", "api"]
                     user:
                       id: 102
                       name: "박리뷰"
@@ -1338,7 +1331,7 @@ paths:
       summary: "리뷰 제출(요청) 목록 조회"
       description: "리뷰 제출(요청) 목록을 조회합니다. 인증된 사용자를 기준으로 '자신이 보낸 요청', '자신이 받은 요청'(리뷰어의 경우), 또는 '모든 관련된 요청' 등으로 필터링할 수 있으며, 페이지네이션을 통해 결과를 제공합니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: type
           in: query
@@ -1346,7 +1339,7 @@ paths:
           description: "조회할 제출 목록의 타입. `sent`: 내가 보낸 요청, `received`: 내가 받은 요청 (리뷰어만 해당), `all`: 나와 관련된 모든 요청. 기본값은 `all` 또는 사용자의 역할에 따라 적절히 설정될 수 있습니다."
           schema:
             type: string
-            enum: [ sent, received, all ]
+            enum: [sent, received, all]
             example: "sent"
         - name: page
           in: query
@@ -1390,7 +1383,7 @@ paths:
                     - id: 1001
                       reviewee:
                         id: 1
-                        preferences: [ "Java", "Spring Boot" ]
+                        preferences: ["Java", "Spring Boot"]
                         user:
                           id: 101
                           name: "김리뷰"
@@ -1399,9 +1392,9 @@ paths:
                         updatedAt: "2024-05-01T10:00:00Z"
                       reviewer:
                         id: 2
-                        preferences: [ "Python", "Django" ]
+                        preferences: ["Python", "Django"]
                         bio: "10년차 백엔드 개발자입니다."
-                        tags: [ "backend", "python", "api" ]
+                        tags: ["backend", "python", "api"]
                         user:
                           id: 102
                           name: "박리뷰"
@@ -1434,7 +1427,7 @@ paths:
       summary: "특정 리뷰 제출(요청) 상세 조회"
       description: "지정된 ID에 해당하는 리뷰 제출(요청) 건의 상세 정보를 조회합니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: submissionId
           in: path
@@ -1491,7 +1484,7 @@ paths:
       summary: "리뷰 제출(요청) 취소"
       description: "리뷰이가 자신이 생성한 특정 리뷰 제출(요청) 건을 취소합니다. 이미 리뷰가 진행 중이거나 완료된 경우에는 취소가 불가능할 수 있습니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: submissionId
           in: path
@@ -1558,7 +1551,7 @@ paths:
       summary: "특정 리뷰 상세 조회"
       description: "지정된 ID에 해당하는 단일 리뷰의 상세 정보를 조회합니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: reviewId
           in: path
@@ -1582,31 +1575,33 @@ paths:
               example:
                 message: "리뷰 정보 조회 성공"
                 data:
-                  id: 201
-                  reviewer:
-                    id: 2
-                    preferences: [ "Python", "Django" ]
-                    bio: "10년차 백엔드 개발자입니다."
-                    tags: [ "backend", "python", "api" ]
-                    user:
-                      id: 102
-                      name: "박리뷰"
-                      email: "reviewer@example.com"
-                    createdAt: "2024-05-01T10:00:00Z"
-                    updatedAt: "2024-05-01T10:00:00Z"
+                  id: 1001
                   reviewee:
                     id: 1
-                    preferences: [ "Java", "Spring Boot" ]
+                    preferences: ["Java", "Spring Boot"]
                     user:
                       id: 101
                       name: "김리뷰"
                       email: "reviewee@example.com"
                     createdAt: "2024-05-01T10:00:00Z"
                     updatedAt: "2024-05-01T10:00:00Z"
-                  reviewSubmissionId: 1001
-                  reviewContent: "코드 잘 봤습니다. UserDTO 네이밍을 UserRequestDTO 등으로 변경하는 것이 좋겠습니다."
+                  reviewer:
+                    id: 2
+                    preferences: ["Python", "Django"]
+                    bio: "10년차 백엔드 개발자입니다."
+                    tags: ["backend", "python", "api"]
+                    user:
+                      id: 102
+                      name: "박리뷰"
+                      email: "reviewer@example.com"
+                    createdAt: "2024-05-01T10:00:00Z"
+                    updatedAt: "2024-05-01T10:00:00Z"
+                  gitUrl: "https://github.com/user/project/pull/1"
+                  requestDetails: "회원가입 기능 구현 관련 코드 리뷰 부탁드립니다."
+                  status: "PENDING"
                   createdAt: "2024-05-16T10:00:00Z"
                   updatedAt: "2024-05-16T10:00:00Z"
+                  reviewContent: "코드 잘 봤습니다. UserDTO 네이밍을 UserRequestDTO 등으로 변경하는 것이 좋겠습니다."
         "401":
           description: "인증되지 않은 사용자 또는 해당 리뷰에 접근 권한이 없는 사용자"
           content:
@@ -1637,7 +1632,7 @@ paths:
       summary: "리뷰 수정"
       description: "리뷰를 작성한 원본 리뷰어가 특정 리뷰의 내용을 수정합니다. 수정 기한이 있거나, 특정 조건 하에서만 수정이 가능할 수 있습니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: reviewId
           in: path
@@ -1670,8 +1665,33 @@ paths:
               example:
                 message: "리뷰가 성공적으로 수정되었습니다."
                 data:
-                  id: 201
-                  # ... (수정된 ReadReviewResponse 내용) ...
+                  id: 1001
+                  reviewee:
+                    id: 1
+                    preferences: ["Java", "Spring Boot"]
+                    user:
+                      id: 101
+                      name: "김리뷰"
+                      email: "reviewee@example.com"
+                    createdAt: "2024-05-01T10:00:00Z"
+                    updatedAt: "2024-05-01T10:00:00Z"
+                  reviewer:
+                    id: 2
+                    preferences: ["Python", "Django"]
+                    bio: "10년차 백엔드 개발자입니다."
+                    tags: ["backend", "python", "api"]
+                    user:
+                      id: 102
+                      name: "박리뷰"
+                      email: "reviewer@example.com"
+                    createdAt: "2024-05-01T10:00:00Z"
+                    updatedAt: "2024-05-01T10:00:00Z"
+                  gitUrl: "https://github.com/user/project/pull/1"
+                  requestDetails: "회원가입 기능 구현 관련 코드 리뷰 부탁드립니다."
+                  status: "PENDING"
+                  createdAt: "2024-05-16T10:00:00Z"
+                  updatedAt: "2024-05-16T10:00:00Z"
+                  reviewContent: "코드 잘 봤습니다. UserDTO 네이밍을 UserRequestDTO 등으로 변경하는 것이 좋겠습니다."
         "400":
           description: "잘못된 요청 (예: 수정할 내용 누락)"
           content:
@@ -1712,7 +1732,7 @@ paths:
       summary: "특정 제출 건에 대한 새 리뷰 작성"
       description: "리뷰어가 특정 리뷰 제출(요청) 건에 대해 리뷰를 작성하여 제출합니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: submissionId
           in: path
@@ -1747,31 +1767,33 @@ paths:
               example:
                 message: "리뷰가 성공적으로 작성되었습니다."
                 data:
-                  id: 203
-                  reviewer:
-                    id: 2
-                    preferences: [ "Python", "Django" ]
-                    bio: "10년차 백엔드 개발자입니다."
-                    tags: [ "backend", "python", "api" ]
-                    user:
-                      id: 102
-                      name: "박리뷰"
-                      email: "reviewer@example.com"
-                    createdAt: "2024-05-01T10:00:00Z"
-                    updatedAt: "2024-05-01T10:00:00Z"
+                  id: 1001
                   reviewee:
                     id: 1
-                    preferences: [ "Java", "Spring Boot" ]
+                    preferences: ["Java", "Spring Boot"]
                     user:
                       id: 101
                       name: "김리뷰"
                       email: "reviewee@example.com"
                     createdAt: "2024-05-01T10:00:00Z"
                     updatedAt: "2024-05-01T10:00:00Z"
-                  reviewSubmissionId: 1001
+                  reviewer:
+                    id: 2
+                    preferences: ["Python", "Django"]
+                    bio: "10년차 백엔드 개발자입니다."
+                    tags: ["backend", "python", "api"]
+                    user:
+                      id: 102
+                      name: "박리뷰"
+                      email: "reviewer@example.com"
+                    createdAt: "2024-05-01T10:00:00Z"
+                    updatedAt: "2024-05-01T10:00:00Z"
+                  gitUrl: "https://github.com/user/project/pull/1"
+                  requestDetails: "회원가입 기능 구현 관련 코드 리뷰 부탁드립니다."
+                  status: "PENDING"
+                  createdAt: "2024-05-16T10:00:00Z"
+                  updatedAt: "2024-05-16T10:00:00Z"
                   reviewContent: "전반적으로 코드가 깔끔하고 좋습니다. 다만, UserServiceImpl의 특정 메서드에서 예외 처리 보강이 필요해 보입니다."
-                  createdAt: "2024-05-19T10:00:00Z"
-                  updatedAt: "2024-05-19T10:00:00Z"
         "400":
           description: "잘못된 요청 (예: 필수 필드 누락, 존재하지 않는 submissionId)"
           content:
@@ -1812,7 +1834,7 @@ paths:
       summary: "리뷰 목록 조회"
       description: "다양한 조건에 따라 리뷰 목록을 조회합니다. 페이지네이션을 지원합니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: submissionId
           in: query
@@ -1872,56 +1894,60 @@ paths:
                   last: true
                   numberOfElements: 2
                   content:
-                    - id: 201
-                      reviewer:
-                        id: 2
-                        preferences: [ "Python", "Django" ]
-                        bio: "10년차 백엔드 개발자입니다."
-                        tags: [ "backend", "python", "api" ]
-                        user:
-                          id: 102
-                          name: "박리뷰"
-                          email: "reviewer@example.com"
-                        createdAt: "2024-05-01T10:00:00Z"
-                        updatedAt: "2024-05-01T10:00:00Z"
+                    - id: 1001
                       reviewee:
                         id: 1
-                        preferences: [ "Java", "Spring Boot" ]
+                        preferences: ["Java", "Spring Boot"]
                         user:
                           id: 101
                           name: "김리뷰"
                           email: "reviewee@example.com"
                         createdAt: "2024-05-01T10:00:00Z"
                         updatedAt: "2024-05-01T10:00:00Z"
-                      reviewSubmissionId: 1001
-                      reviewContent: "좋은 코드입니다."
+                      reviewer:
+                        id: 2
+                        preferences: ["Python", "Django"]
+                        bio: "10년차 백엔드 개발자입니다."
+                        tags: ["backend", "python", "api"]
+                        user:
+                          id: 102
+                          name: "박리뷰"
+                          email: "reviewer@example.com"
+                        createdAt: "2024-05-01T10:00:00Z"
+                        updatedAt: "2024-05-01T10:00:00Z"
+                      gitUrl: "https://github.com/user/project/pull/1"
+                      requestDetails: "회원가입 기능 구현 관련 코드 리뷰 부탁드립니다."
+                      status: "PENDING"
                       createdAt: "2024-05-16T10:00:00Z"
                       updatedAt: "2024-05-16T10:00:00Z"
-                    - id: 202
-                      reviewer:
-                        id: 3
-                        preferences: [ "JavaScript", "React" ]
-                        bio: "5년차 프론트엔드 개발자입니다."
-                        tags: [ "frontend", "javascript", "react" ]
-                        user:
-                          id: 103
-                          name: "최리뷰"
-                          email: "reviewer2@example.com"
-                        createdAt: "2024-05-02T10:00:00Z"
-                        updatedAt: "2024-05-02T10:00:00Z"
+                      reviewContent: "코드 잘 봤습니다. UserDTO 네이밍을 UserRequestDTO 등으로 변경하는 것이 좋겠습니다."
+                    - id: 1002
                       reviewee:
                         id: 4
-                        preferences: [ "Python", "Flask" ]
+                        preferences: ["Python", "Flask"]
                         user:
                           id: 104
                           name: "이리뷰이"
                           email: "reviewee2@example.com"
                         createdAt: "2024-05-03T10:00:00Z"
                         updatedAt: "2024-05-03T10:00:00Z"
-                      reviewSubmissionId: 1002
-                      reviewContent: "몇 가지 개선점이 보입니다."
+                      reviewer:
+                        id: 3
+                        preferences: ["JavaScript", "React"]
+                        bio: "5년차 프론트엔드 개발자입니다."
+                        tags: ["frontend", "javascript", "react"]
+                        user:
+                          id: 103
+                          name: "최리뷰"
+                          email: "reviewer2@example.com"
+                        createdAt: "2024-05-02T10:00:00Z"
+                        updatedAt: "2024-05-02T10:00:00Z"
+                      gitUrl: "https://github.com/user/project/pull/2"
+                      requestDetails: "몇 가지 개선점이 보입니다."
+                      status: "REVIEWED"
                       createdAt: "2024-05-17T11:00:00Z"
                       updatedAt: "2024-05-17T11:00:00Z"
+                      reviewContent: "몇 가지 개선점이 보입니다."
         "401":
           description: "인증되지 않은 사용자"
           content:
@@ -1938,7 +1964,7 @@ paths:
       summary: "리뷰어 목록 조회"
       description: "등록된 리뷰어들의 프로필 목록을 조회합니다. 전문 분야, 태그 등으로 필터링할 수 있으며 페이지네이션을 지원합니다."
       security:
-        - bearerAuth: [ ]
+        - bearerAuth: []
       parameters:
         - name: preferences
           in: query
@@ -1992,10 +2018,15 @@ paths:
                   numberOfElements: 1
                   content:
                     - id: 12
-                      user: { id: 102, name: "박전문", email: "reviewer1@example.com" }
-                      preferences: [ "Java", "Spring Boot" ]
+                      user:
+                        {
+                          id: 102,
+                          name: "박전문",
+                          email: "reviewer1@example.com",
+                        }
+                      preferences: ["Java", "Spring Boot"]
                       bio: "Java, Spring 전문가입니다."
-                      tags: [ "java", "spring", "backend" ]
+                      tags: ["java", "spring", "backend"]
                       createdAt: "2024-03-10T11:00:00Z"
                       updatedAt: "2024-05-01T17:30:00Z"
         "401":


### PR DESCRIPTION
## 변경 사항 요약

이 PR은 `openapi.yaml` 파일의 다음과 같은 내용을 수정합니다:

1.  **YAML 포맷팅 개선:**
    *   전반적인 따옴표 사용의 일관성을 확보했습니다.
    *   배열 선언 시 항목 사이의 불필요한 공백을 제거하여 가독성을 높였습니다.
    *   `security` 항목의 `bearerAuth: []`에서 내부 공백을 제거했습니다.

2.  **`ReadReviewResponse` 스키마 수정:**
    *   `components.schemas.ReadReviewResponse`의 `allOf` 참조를 기존 `BaseAuditResponse`에서 `ReadReviewSubmissionResponse`로 변경했습니다.
    *   이에 따라 `ReadReviewResponse`의 `example` 값도 `ReadReviewSubmissionResponse`의 구조에 맞게 업데이트되었습니다. 이는 리뷰 상세 정보 조회 시 더 많은 컨텍스트를 제공하기 위함입니다.

## 변경 이유

*   YAML 파일의 일관성 있는 포맷팅을 통해 유지보수성을 향상시킵니다.
*   `ReadReviewResponse` 스키마 변경은 API 명세의 정확성을 높이고, 클라이언트가 리뷰 정보를 더 풍부하게 이해할 수 있도록 지원합니다.

