### PR TITLE
Review Submission 구현 및 개선

### DIFF
--- a/src/main/java/konkuk/ptal/controller/ReviewSubmissionController.java
+++ b/src/main/java/konkuk/ptal/controller/ReviewSubmissionController.java
@@ -1,0 +1,74 @@
+package konkuk.ptal.controller;
+
+import jakarta.validation.Valid;
+import konkuk.ptal.domain.UserPrincipal;
+import konkuk.ptal.domain.enums.ReviewSubmissionType;
+import konkuk.ptal.dto.api.ApiResponse;
+import konkuk.ptal.dto.api.ResponseCode;
+import konkuk.ptal.dto.request.CreateReviewSubmissionRequest;
+import konkuk.ptal.dto.response.ListReviewSubmissionResponse;
+import konkuk.ptal.dto.response.ReadReviewSubmissionResponse;
+import konkuk.ptal.entity.ReviewSubmission;
+import konkuk.ptal.service.IReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+
+@RestController
+@RequestMapping("/api/v1/review-submissions")
+@RequiredArgsConstructor
+public class ReviewSubmissionController {
+    private final IReviewService reviewService;
+
+    @PostMapping("/new")
+    public ResponseEntity<ApiResponse<ReadReviewSubmissionResponse>> createReviewSubmission(
+            @Valid @RequestBody CreateReviewSubmissionRequest request,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        ReviewSubmission reviewSubmission = reviewService.createReviewSubmission(request,userPrincipal);
+        ReadReviewSubmissionResponse responseDto = ReadReviewSubmissionResponse.from(reviewSubmission);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(ResponseCode.REVIEW_SUBMISSION_CREATED.getMessage(), responseDto));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<ListReviewSubmissionResponse>> getReviewSubmissions(
+            @RequestParam(name = "type", required = false, defaultValue = "all") ReviewSubmissionType type,
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "size", required = false, defaultValue = "10") int size,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        Page<ReviewSubmission> submissions = reviewService.getReviewSubmissions(type, page, size, userPrincipal);
+        ListReviewSubmissionResponse responsedtos = ListReviewSubmissionResponse.from(submissions);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responsedtos));
+    }
+
+    @GetMapping("/{submissionId}")
+    public ResponseEntity<ApiResponse<ReadReviewSubmissionResponse>> getReviewSubmissionById(
+            @PathVariable("submissionId") Long submissionId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        ReviewSubmission reviewSubmission = reviewService.getReviewSubmission(submissionId, userPrincipal);
+        ReadReviewSubmissionResponse responseDto = ReadReviewSubmissionResponse.from(reviewSubmission);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
+    }
+
+    @PatchMapping("/{submissionId}")
+    public ResponseEntity<ApiResponse<ReadReviewSubmissionResponse>> cancelReviewSubmission(
+            @PathVariable("submissionId") Long submissionId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal) {
+        ReviewSubmission canceledReviewSubmission = reviewService.cancelReviewSubmission(submissionId, userPrincipal);
+        ReadReviewSubmissionResponse responseDto = ReadReviewSubmissionResponse.from(canceledReviewSubmission);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(ResponseCode.REVIEW_SUBMISSION_CANCELED.getMessage(), responseDto));
+    }
+
+}
+

--- a/src/main/java/konkuk/ptal/controller/UserController.java
+++ b/src/main/java/konkuk/ptal/controller/UserController.java
@@ -112,8 +112,5 @@ public class UserController {
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(ResponseCode.DATA_UPDATE_SUCCESS.getMessage(), responseDto));
     }
-
-// 추가로 리뷰어목록도 누락돼있는거같은데 자세하게 함 봐야할듯..
-// 문서에 있는 List쪽은 다 누락된거같음
 }
 

--- a/src/main/java/konkuk/ptal/domain/enums/ReviewSubmissionStatus.java
+++ b/src/main/java/konkuk/ptal/domain/enums/ReviewSubmissionStatus.java
@@ -1,6 +1,6 @@
 package konkuk.ptal.domain.enums;
 
-public enum ReviewRequestStatus {
+public enum ReviewSubmissionStatus {
     PENDING,
     APPROVED,
     REJECTED,

--- a/src/main/java/konkuk/ptal/domain/enums/ReviewSubmissionType.java
+++ b/src/main/java/konkuk/ptal/domain/enums/ReviewSubmissionType.java
@@ -1,0 +1,7 @@
+package konkuk.ptal.domain.enums;
+
+public enum ReviewSubmissionType {
+    SENT,
+    RECEIVED,
+    ALL
+}

--- a/src/main/java/konkuk/ptal/dto/api/ErrorCode.java
+++ b/src/main/java/konkuk/ptal/dto/api/ErrorCode.java
@@ -22,7 +22,8 @@ public enum ErrorCode {
     FILE_LIST_ERROR("파일 리스트를 가져오는 데 에러가 발생했습니다."),
     ENTITY_NOT_FOUND("엔티티를 찾을 수 없습니다."),
     FILE_NOT_BELONG_TO_SESSION("코드 파일이 리뷰세션에 속하지 않습니다."),
-    PARENT_COMMENT_NOT_BELONG_TO_SESSION("부모 댓글이 세션에 속하지 않습니다.");
+    PARENT_COMMENT_NOT_BELONG_TO_SESSION("부모 댓글이 세션에 속하지 않습니다."),
+    SUBMISSION_CANCEL_UNAVAILABLE("이미 진행 중이거나 취소된 리뷰 제출은 취소할 수 없습니다.");
 
 
     private final String message;

--- a/src/main/java/konkuk/ptal/dto/api/ResponseCode.java
+++ b/src/main/java/konkuk/ptal/dto/api/ResponseCode.java
@@ -15,7 +15,9 @@ public enum ResponseCode {
     REVIEWEE_REGISTER_SUCCESS("리뷰이 등록 성공"),
     REVIEW_CREATED("리뷰 생성 성공"),
     REVIEW_UPDATED("리뷰 업데이트 성공"),
-    TOKEN_REFRESH_SUCCESS("토큰 리프레시 성공");
+    TOKEN_REFRESH_SUCCESS("토큰 리프레시 성공"),
+    REVIEW_SUBMISSION_CREATED("리뷰 요청 성공"),
+    REVIEW_SUBMISSION_CANCELED("리뷰 요청 취소 성공");
 
     private final String message;
 

--- a/src/main/java/konkuk/ptal/dto/request/CreateReviewSubmissionRequest.java
+++ b/src/main/java/konkuk/ptal/dto/request/CreateReviewSubmissionRequest.java
@@ -1,0 +1,24 @@
+package konkuk.ptal.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class CreateReviewSubmissionRequest {
+    @NotNull(message = "리뷰어 ID는 필수입니다")
+    private Long reviewerId;
+
+    @NotBlank(message = "Git URL은 필수입니다")
+    @Pattern(regexp = "^https?://.*\\.git$", message = "올바른 Git 저장소 URL 형식이어야 합니다")
+    private String gitUrl;
+
+    @NotBlank(message = "브랜치명은 필수입니다")
+    private String branch;
+
+    @NotBlank(message = "리뷰 요청 상세 내용은 필수입니다")
+    private String requestDetails;
+}

--- a/src/main/java/konkuk/ptal/dto/response/ListReviewSubmissionResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ListReviewSubmissionResponse.java
@@ -1,0 +1,30 @@
+package konkuk.ptal.dto.response;
+
+import konkuk.ptal.entity.ReviewSubmission;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+@NoArgsConstructor
+@EqualsAndHashCode(callSuper = true)
+public class ListReviewSubmissionResponse extends BasePageResponse{
+    private List<ReadReviewSubmissionResponse> content;
+    public ListReviewSubmissionResponse(Page<ReviewSubmission> page, List<ReadReviewSubmissionResponse> content) {
+        super(page);
+        this.content = content;
+    }
+
+    public static ListReviewSubmissionResponse from(Page<ReviewSubmission> reviewSubmissionPage) {
+
+        List<ReadReviewSubmissionResponse> content = reviewSubmissionPage.getContent().stream()
+                .map(ReadReviewSubmissionResponse::from)
+                .collect(Collectors.toList());
+
+        return new ListReviewSubmissionResponse(reviewSubmissionPage, content);
+    }
+}

--- a/src/main/java/konkuk/ptal/dto/response/ProjectFileSystem.java
+++ b/src/main/java/konkuk/ptal/dto/response/ProjectFileSystem.java
@@ -1,0 +1,12 @@
+package konkuk.ptal.dto.response;
+
+import lombok.Data;
+
+@Data
+public class ProjectFileSystem {
+    Long submissionId;
+    String branch;
+    //FileNode rootDirectory;
+    Long totalFiles;
+    Long totalSize;
+}

--- a/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
@@ -5,6 +5,8 @@ import konkuk.ptal.entity.ReviewSubmission;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDateTime;
+
 
 @Data
 @Builder
@@ -17,6 +19,8 @@ public class ReadReviewSubmissionResponse {
     String requestDetails;
     ReviewSubmissionStatus status;
     ProjectFileSystem fileSystem;
+    LocalDateTime createdAt;
+    LocalDateTime updatedAt;
 
     public static ReadReviewSubmissionResponse from(ReviewSubmission reviewSubmission) {
 
@@ -27,6 +31,9 @@ public class ReadReviewSubmissionResponse {
                 .reviewee(ReadRevieweeResponse.from(reviewSubmission.getReviewee()))
                 .gitUrl(reviewSubmission.getGitUrl())
                 .branch(reviewSubmission.getBranch())
+                .createdAt(baseAuditResponse.getCreatedAt())
+                .updatedAt(baseAuditResponse.getUpdatedAt())
+                //.fileSystem()
                 .build();
     }
 }

--- a/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
@@ -1,0 +1,32 @@
+package konkuk.ptal.dto.response;
+
+import konkuk.ptal.domain.enums.ReviewSubmissionStatus;
+import konkuk.ptal.entity.ReviewSubmission;
+import lombok.Builder;
+import lombok.Data;
+
+
+@Data
+@Builder
+public class ReadReviewSubmissionResponse {
+    Long id;
+    ReadReviewerResponse reviewer;
+    ReadRevieweeResponse reviewee;
+    String gitUrl;
+    String branch;
+    String requestDetails;
+    ReviewSubmissionStatus status;
+    ProjectFileSystem fileSystem;
+
+    public static ReadReviewSubmissionResponse from(ReviewSubmission reviewSubmission) {
+
+        BaseAuditResponse baseAuditResponse = BaseAuditResponse.from(reviewSubmission.getCreatedAt());
+        return ReadReviewSubmissionResponse.builder()
+                .id(reviewSubmission.getId())
+                .reviewer(ReadReviewerResponse.from(reviewSubmission.getReviewer()))
+                .reviewee(ReadRevieweeResponse.from(reviewSubmission.getReviewee()))
+                .gitUrl(reviewSubmission.getGitUrl())
+                .branch(reviewSubmission.getBranch())
+                .build();
+    }
+}

--- a/src/main/java/konkuk/ptal/entity/ReviewSubmission.java
+++ b/src/main/java/konkuk/ptal/entity/ReviewSubmission.java
@@ -1,14 +1,14 @@
 package konkuk.ptal.entity;
 
 import jakarta.persistence.*;
-import konkuk.ptal.domain.enums.ReviewRequestStatus;
-import konkuk.ptal.dto.request.CreateReviewSessionRequest;
+import konkuk.ptal.domain.enums.ReviewSubmissionStatus;
+import konkuk.ptal.dto.request.CreateReviewSubmissionRequest;
 import lombok.*;
 
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "review_sessions")
+@Table(name = "review_submissions")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -17,17 +17,9 @@ import java.time.LocalDateTime;
 public class ReviewSubmission {
 
     @Id
-    @Column(name = "review_session_id")
+    @Column(name = "review_submission_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-
-    @Lob
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String title;
-
-    @Lob
-    @Column(nullable = false, columnDefinition = "TEXT")
-    private String description;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reviewee_id", nullable = false)
@@ -38,15 +30,18 @@ public class ReviewSubmission {
     private Reviewer reviewer;
 
     @Column(nullable = false)
-    private String githubLink;
+    private String gitUrl;
+
+    @Column(nullable = false)
+    private String branch;
 
     @Lob
     @Column(nullable = false, columnDefinition = "TEXT")
-    private String absolutePath;
+    private String requestDetails;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private ReviewRequestStatus status;
+    private ReviewSubmissionStatus status;
 
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -66,14 +61,12 @@ public class ReviewSubmission {
 
     }
 
-    public static ReviewSubmission createReviewSession(String absolutePath, ReviewRequestStatus status, Reviewer reviewer, Reviewee reviewee, CreateReviewSessionRequest dto){
+    public static ReviewSubmission createReviewSubmission(ReviewSubmissionStatus status, Reviewer reviewer, Reviewee reviewee, CreateReviewSubmissionRequest dto){
         return ReviewSubmission.builder()
-                .title(dto.getTitle())
-                .description(dto.getDescription())
+                .requestDetails(dto.getRequestDetails())
                 .reviewee(reviewee)
                 .reviewer(reviewer)
-                .githubLink(dto.getGithubLink())
-                .absolutePath(absolutePath)
+                .gitUrl(dto.getGitUrl())
                 .status(status)
                 .build();
     }

--- a/src/main/java/konkuk/ptal/repository/ReviewSessionRepository.java
+++ b/src/main/java/konkuk/ptal/repository/ReviewSessionRepository.java
@@ -1,9 +1,0 @@
-package konkuk.ptal.repository;
-
-import konkuk.ptal.entity.ReviewSubmission;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface ReviewSessionRepository extends JpaRepository<ReviewSubmission, Long> {
-}

--- a/src/main/java/konkuk/ptal/repository/ReviewSubmissionRepository.java
+++ b/src/main/java/konkuk/ptal/repository/ReviewSubmissionRepository.java
@@ -1,0 +1,26 @@
+package konkuk.ptal.repository;
+
+import konkuk.ptal.entity.ReviewSubmission;
+import konkuk.ptal.entity.Reviewee;
+import konkuk.ptal.entity.Reviewer;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ReviewSubmissionRepository extends JpaRepository<ReviewSubmission, Long> {
+    Optional<ReviewSubmission> findByIdAndReviewee_User_IdOrIdAndReviewer_User_Id(
+            Long submissionId1, Long revieweeUserId,
+            Long submissionId2, Long reviewerUserId
+    );
+    Optional<ReviewSubmission> findByIdAndReviewee_User_Id(Long submissionId, Long revieweeUserId);
+    Page<ReviewSubmission> findByReviewee(Reviewee reviewee, Pageable pageable);
+
+    Page<ReviewSubmission> findByReviewer(Reviewer reviewer, Pageable pageable);
+
+    Page<ReviewSubmission> findByReviewee_User_IdOrReviewer_User_Id(Long revieweeUserId, Long reviewerUserId, Pageable pageable);
+
+}

--- a/src/main/java/konkuk/ptal/repository/RevieweeRepository.java
+++ b/src/main/java/konkuk/ptal/repository/RevieweeRepository.java
@@ -4,6 +4,9 @@ import konkuk.ptal.entity.Reviewee;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface RevieweeRepository extends JpaRepository<Reviewee, Long> {
+    Optional<Reviewee> findByUser_Id(Long userId);
 }

--- a/src/main/java/konkuk/ptal/repository/ReviewerRepository.java
+++ b/src/main/java/konkuk/ptal/repository/ReviewerRepository.java
@@ -1,9 +1,14 @@
 package konkuk.ptal.repository;
 
+import konkuk.ptal.entity.Reviewee;
 import konkuk.ptal.entity.Reviewer;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ReviewerRepository extends JpaRepository<Reviewer, Long> {
+    Optional<Reviewer> findByUser_Id(Long userId);
+
 } 

--- a/src/main/java/konkuk/ptal/service/IReviewService.java
+++ b/src/main/java/konkuk/ptal/service/IReviewService.java
@@ -1,9 +1,17 @@
 package konkuk.ptal.service;
 
+import konkuk.ptal.domain.UserPrincipal;
+import konkuk.ptal.domain.enums.ReviewSubmissionType;
 import konkuk.ptal.dto.request.CreateReviewCommentRequest;
 import konkuk.ptal.dto.request.CreateReviewSessionRequest;
+import konkuk.ptal.dto.request.CreateReviewSubmissionRequest;
+import konkuk.ptal.dto.response.ListReviewSubmissionResponse;
+import konkuk.ptal.dto.response.ReadReviewSubmissionResponse;
 import konkuk.ptal.entity.ReviewComment;
 import konkuk.ptal.entity.ReviewSubmission;
+import konkuk.ptal.exception.BadRequestException;
+import konkuk.ptal.exception.EntityNotFoundException;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -15,7 +23,7 @@ public interface IReviewService {
      * @param request 리뷰 세션 생성을 위한 상세 정보를 담고 있는 요청 객체
      * @return 새로 생성된 {@link ReviewSubmission} 객체입니다.
      */
-    ReviewSubmission createReviewSession(CreateReviewSessionRequest request);
+    ReviewSubmission createReviewSubmission(CreateReviewSubmissionRequest request, UserPrincipal userPrincipal);
 
     /**
      * 특정 코드 리뷰 세션의 상세 정보를 조회합니다.
@@ -23,7 +31,28 @@ public interface IReviewService {
      * @param submissionId 리뷰 세션의 고유 식별자입니다.
      * @return 기본 세션 정보와 해당 세션 내의 모든 파일 목록을 포함하는 {@link ReviewSubmission} 객체입니다.
      */
-    ReviewSubmission getReviewSession(Long submissionId);
+    ReviewSubmission getReviewSubmission(Long submissionId, UserPrincipal userPrincipal);
+
+    /**
+     * 리뷰 제출(요청) 목록을 조회합니다.
+     * @param type 조회할 제출 목록의 타입 (sent, received, all)
+     * @param page 페이지 번호 (0부터 시작)
+     * @param size 한 페이지당 항목 수
+     * @param userPrincipal 현재 인증된 사용자 정보
+     * @return 필터링 및 페이지네이션된 리뷰 제출 목록 DTO
+     */
+    Page<ReviewSubmission> getReviewSubmissions(ReviewSubmissionType type, int page, int size, UserPrincipal userPrincipal);
+
+    /**
+     * 특정 리뷰 제출(요청)을 취소합니다.
+     * @param submissionId 취소할 리뷰 제출의 ID
+     * @param userPrincipal 현재 인증된 사용자 정보
+     * @return 취소된 리뷰 제출의 상세 정보 DTO
+     * @throws EntityNotFoundException 해당 submissionId를 찾을 수 없거나 접근 권한이 없을 때
+     * @throws BadRequestException 이미 취소되었거나 리뷰가 시작된 제출을 취소하려 할 때
+     */
+    ReviewSubmission cancelReviewSubmission(Long submissionId, UserPrincipal userPrincipal);
+
 
     /**
      * 특정 리뷰 세션 내에 새로운 댓글을 생성합니다.
@@ -59,4 +88,5 @@ public interface IReviewService {
      * @return 댓글이 성공적으로 삭제(소프트 삭제)되었으면 `true`, 그렇지 않으면 `false`를 반환합니다.
      */
     boolean deleteReviewComment(String commentId);
+
 }


### PR DESCRIPTION
## Feature: 리뷰 제출(Review Submission) API 구현 및 개선

#47 에 관련된 PR

### 주요 변경 사항
1. 리뷰 제출 생성 (`POST /api/v1/review-submissions/new`)
2. 리뷰 제출 목록 조회 (`GET /api/v1/review-submissions`)
3. 단일 리뷰 제출 상세 조회 (`GET /api/v1/review-submissions/{submissionId}`)
4. 리뷰 제출 취소 (`PATCH /api/v1/review-submissions/{submissionId}`)

### Note
`ReadReviewSubmissionResponse`의 경우 `ProjectFileSystem`의 의존성을 가지고 있어 File쪽 구현 후 
해당 dto 및 관련 다수 코드들이 수정돼야할 것으로 보임. 
