### PR TITLE
feat: Integrate Git repository file system data into review DTOs

### DIFF
--- a/src/main/java/konkuk/ptal/controller/ReviewController.java
+++ b/src/main/java/konkuk/ptal/controller/ReviewController.java
@@ -7,8 +7,11 @@ import konkuk.ptal.dto.api.ResponseCode;
 import konkuk.ptal.dto.request.CreateReviewRequest;
 import konkuk.ptal.dto.request.UpdateReviewRequest;
 import konkuk.ptal.dto.response.ListReviewsResponse;
+import konkuk.ptal.dto.response.ProjectFileSystem;
 import konkuk.ptal.dto.response.ReadReviewResponse;
 import konkuk.ptal.entity.Review;
+import konkuk.ptal.entity.ReviewSubmission;
+import konkuk.ptal.service.IFileService;
 import konkuk.ptal.service.IReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -25,6 +28,7 @@ import java.util.List;
 
 public class ReviewController {
     private final IReviewService reviewService;
+    private final IFileService fileService;
 
     @PostMapping("/review-submissions/{submissionId}/reviews")
     public ResponseEntity<ApiResponse<ReadReviewResponse>> createReview(
@@ -32,7 +36,9 @@ public class ReviewController {
             @Valid @RequestBody CreateReviewRequest request,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         Review review = reviewService.createReview(submissionId, request, userPrincipal);
-        ReadReviewResponse responseDto = ReadReviewResponse.from(review);
+        ReviewSubmission reviewSubmission = review.getReviewSubmission();
+        ProjectFileSystem fileSystem = fileService.getProjectFileSystem(reviewSubmission.getGitUrl(), reviewSubmission.getBranch(), reviewSubmission.getId());
+        ReadReviewResponse responseDto = ReadReviewResponse.from(review, fileSystem);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(ResponseCode.REVIEW_CREATED.getMessage(), responseDto));
@@ -44,7 +50,9 @@ public class ReviewController {
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
         Review review = reviewService.getReview(reviewId, userPrincipal);
-        ReadReviewResponse responseDto = ReadReviewResponse.from(review);
+        ReviewSubmission reviewSubmission = review.getReviewSubmission();
+        ProjectFileSystem fileSystem = fileService.getProjectFileSystem(reviewSubmission.getGitUrl(), reviewSubmission.getBranch(), reviewSubmission.getId());
+        ReadReviewResponse responseDto = ReadReviewResponse.from(review, fileSystem);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
@@ -57,7 +65,9 @@ public class ReviewController {
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
         Review updatedReview = reviewService.updateReview(reviewId, request, userPrincipal);
-        ReadReviewResponse responseDto = ReadReviewResponse.from(updatedReview);
+        ReviewSubmission reviewSubmission = updatedReview.getReviewSubmission();
+        ProjectFileSystem fileSystem = fileService.getProjectFileSystem(reviewSubmission.getGitUrl(), reviewSubmission.getBranch(), reviewSubmission.getId());
+        ReadReviewResponse responseDto = ReadReviewResponse.from(updatedReview, fileSystem);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(ResponseCode.REVIEW_UPDATED.getMessage(), responseDto));
@@ -72,8 +82,7 @@ public class ReviewController {
             @RequestParam(name = "size", required = false, defaultValue = "10") int size,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
 
-        Page<Review> reviews = reviewService.getReviews(submissionId, reviewerId, revieweeId, page, size, userPrincipal);
-        ListReviewsResponse responseDtos = ListReviewsResponse.from(reviews);
+        ListReviewsResponse responseDtos = reviewService.getReviews(submissionId, reviewerId, revieweeId, page, size, userPrincipal);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/konkuk/ptal/controller/ReviewSubmissionController.java
+++ b/src/main/java/konkuk/ptal/controller/ReviewSubmissionController.java
@@ -7,8 +7,10 @@ import konkuk.ptal.dto.api.ApiResponse;
 import konkuk.ptal.dto.api.ResponseCode;
 import konkuk.ptal.dto.request.CreateReviewSubmissionRequest;
 import konkuk.ptal.dto.response.ListReviewSubmissionResponse;
+import konkuk.ptal.dto.response.ProjectFileSystem;
 import konkuk.ptal.dto.response.ReadReviewSubmissionResponse;
 import konkuk.ptal.entity.ReviewSubmission;
+import konkuk.ptal.service.IFileService;
 import konkuk.ptal.service.IReviewService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,13 +25,16 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 public class ReviewSubmissionController {
     private final IReviewService reviewService;
+    private final IFileService fileService;
 
     @PostMapping("/new")
     public ResponseEntity<ApiResponse<ReadReviewSubmissionResponse>> createReviewSubmission(
             @Valid @RequestBody CreateReviewSubmissionRequest request,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         ReviewSubmission reviewSubmission = reviewService.createReviewSubmission(request,userPrincipal);
-        ReadReviewSubmissionResponse responseDto = ReadReviewSubmissionResponse.from(reviewSubmission);
+        ProjectFileSystem fileSystem = fileService.getProjectFileSystem(reviewSubmission.getGitUrl(), reviewSubmission.getBranch(), reviewSubmission.getId());
+
+        ReadReviewSubmissionResponse responseDto = ReadReviewSubmissionResponse.from(reviewSubmission, fileSystem);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.success(ResponseCode.REVIEW_SUBMISSION_CREATED.getMessage(), responseDto));
@@ -41,8 +46,7 @@ public class ReviewSubmissionController {
             @RequestParam(name = "page", required = false, defaultValue = "0") int page,
             @RequestParam(name = "size", required = false, defaultValue = "10") int size,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
-        Page<ReviewSubmission> submissions = reviewService.getReviewSubmissions(type, page, size, userPrincipal);
-        ListReviewSubmissionResponse responseDtos = ListReviewSubmissionResponse.from(submissions);
+        ListReviewSubmissionResponse responseDtos = reviewService.getReviewSubmissions(type, page, size, userPrincipal);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDtos));
@@ -53,7 +57,8 @@ public class ReviewSubmissionController {
             @PathVariable("submissionId") Long submissionId,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         ReviewSubmission reviewSubmission = reviewService.getReviewSubmission(submissionId, userPrincipal);
-        ReadReviewSubmissionResponse responseDto = ReadReviewSubmissionResponse.from(reviewSubmission);
+        ProjectFileSystem fileSystem = fileService.getProjectFileSystem(reviewSubmission.getGitUrl(), reviewSubmission.getBranch(), reviewSubmission.getId());
+        ReadReviewSubmissionResponse responseDto = ReadReviewSubmissionResponse.from(reviewSubmission, fileSystem);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
@@ -64,7 +69,8 @@ public class ReviewSubmissionController {
             @PathVariable("submissionId") Long submissionId,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         ReviewSubmission canceledReviewSubmission = reviewService.cancelReviewSubmission(submissionId, userPrincipal);
-        ReadReviewSubmissionResponse responseDto = ReadReviewSubmissionResponse.from(canceledReviewSubmission);
+        ProjectFileSystem fileSystem = fileService.getProjectFileSystem(canceledReviewSubmission.getGitUrl(), canceledReviewSubmission.getBranch(), canceledReviewSubmission.getId());
+        ReadReviewSubmissionResponse responseDto = ReadReviewSubmissionResponse.from(canceledReviewSubmission, fileSystem);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(ResponseCode.REVIEW_SUBMISSION_CANCELED.getMessage(), responseDto));

--- a/src/main/java/konkuk/ptal/domain/enums/FileNodeType.java
+++ b/src/main/java/konkuk/ptal/domain/enums/FileNodeType.java
@@ -1,0 +1,6 @@
+package konkuk.ptal.domain.enums;
+
+public enum FileNodeType {
+    FILE,
+    DIRECTORY
+}

--- a/src/main/java/konkuk/ptal/dto/response/FileContent.java
+++ b/src/main/java/konkuk/ptal/dto/response/FileContent.java
@@ -1,0 +1,28 @@
+package konkuk.ptal.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class FileContent {
+    private String path;
+    private String content;
+    private String encoding;
+    private Long size;
+    private LocalDateTime lastModified;
+    private Integer lineCount;
+
+    public static FileContent from(String path, String content, String encoding, Long size, LocalDateTime lastModified, Integer lineCount){
+        return FileContent.builder()
+                .path(path)
+                .content(content)
+                .encoding(encoding)
+                .size(size)
+                .lastModified(lastModified)
+                .lineCount(lineCount)
+                .build();
+    }
+}

--- a/src/main/java/konkuk/ptal/dto/response/FileNode.java
+++ b/src/main/java/konkuk/ptal/dto/response/FileNode.java
@@ -1,0 +1,36 @@
+package konkuk.ptal.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import konkuk.ptal.domain.enums.FileNodeType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class FileNode {
+    private String name;
+    private String path;
+    private FileNodeType type;
+    private Long size; // 디렉토리인 경우 null
+    private LocalDateTime lastModified;
+    private List<FileNode> children; // 파일인 경우 null
+
+    public static FileNode from(String entryName, String entryPath, FileNodeType fileNodeType, Long fileSize, LocalDateTime lastModified, List<FileNode> children) {
+        return FileNode.builder()
+                .name(entryName)
+                .path(entryPath)
+                .type(fileNodeType)
+                .size(fileSize)
+                .lastModified(lastModified)
+                .children(children)
+                .build();
+    }
+}

--- a/src/main/java/konkuk/ptal/dto/response/GitBranch.java
+++ b/src/main/java/konkuk/ptal/dto/response/GitBranch.java
@@ -1,0 +1,26 @@
+package konkuk.ptal.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+public class GitBranch {
+    private String name;
+    private Boolean isDefault;
+    private String lastCommit;
+    private LocalDateTime lastCommitDate;
+    private String lastCommitMessage;
+
+    public static GitBranch from(String name, Boolean isDefault, String lastCommit, LocalDateTime lastCommitDate, String lastCommitMessage) {
+        return GitBranch.builder()
+                .name(name)
+                .isDefault(isDefault)
+                .lastCommit(lastCommit)
+                .lastCommitDate(lastCommitDate)
+                .lastCommitMessage(lastCommitMessage)
+                .build();
+    }
+}

--- a/src/main/java/konkuk/ptal/dto/response/ListBranchesResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ListBranchesResponse.java
@@ -1,0 +1,22 @@
+package konkuk.ptal.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class ListBranchesResponse {
+    private String gitUrl;
+    private List<GitBranch> branches;
+    private String defaultBranch;
+
+    public static ListBranchesResponse from(String gitUrl, List<GitBranch> branches, String defaultBranch){
+        return ListBranchesResponse.builder()
+                .gitUrl(gitUrl)
+                .branches(branches)
+                .defaultBranch(defaultBranch)
+                .build();
+    }
+}

--- a/src/main/java/konkuk/ptal/dto/response/ListReviewSubmissionResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ListReviewSubmissionResponse.java
@@ -19,12 +19,4 @@ public class ListReviewSubmissionResponse extends BasePageResponse{
         this.content = content;
     }
 
-    public static ListReviewSubmissionResponse from(Page<ReviewSubmission> reviewSubmissionPage) {
-
-        List<ReadReviewSubmissionResponse> content = reviewSubmissionPage.getContent().stream()
-                .map(ReadReviewSubmissionResponse::from)
-                .collect(Collectors.toList());
-
-        return new ListReviewSubmissionResponse(reviewSubmissionPage, content);
-    }
 }

--- a/src/main/java/konkuk/ptal/dto/response/ListReviewsResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ListReviewsResponse.java
@@ -21,13 +21,4 @@ public class ListReviewsResponse extends BasePageResponse{
         this.content = content;
     }
 
-    public static ListReviewsResponse from(Page<Review> reviewPage) {
-
-        List<ReadReviewResponse> content = reviewPage.getContent().stream()
-                .map(ReadReviewResponse::from)
-                .collect(Collectors.toList());
-
-        return new ListReviewsResponse(reviewPage, content);
-    }
-
 }

--- a/src/main/java/konkuk/ptal/dto/response/ProjectFileSystem.java
+++ b/src/main/java/konkuk/ptal/dto/response/ProjectFileSystem.java
@@ -1,12 +1,24 @@
 package konkuk.ptal.dto.response;
 
+import lombok.Builder;
 import lombok.Data;
 
 @Data
+@Builder
 public class ProjectFileSystem {
     Long submissionId;
     String branch;
-    //FileNode rootDirectory;
+    FileNode rootDirectory;
     Long totalFiles;
     Long totalSize;
+
+    public static ProjectFileSystem from(Long submissionId, String branch, FileNode rootDirectory, Long totalFiles, Long totalSize){
+        return ProjectFileSystem.builder()
+                .submissionId(submissionId)
+                .branch(branch)
+                .rootDirectory(rootDirectory)
+                .totalFiles(totalFiles)
+                .totalSize(totalSize)
+                .build();
+    }
 }

--- a/src/main/java/konkuk/ptal/dto/response/ReadReviewResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadReviewResponse.java
@@ -24,7 +24,7 @@ public class ReadReviewResponse {
     LocalDateTime updatedAt;
     String reviewContent;
 
-    public static ReadReviewResponse from(Review review){
+    public static ReadReviewResponse from(Review review, ProjectFileSystem fileSystem){
         return ReadReviewResponse.builder()
                 .reviewContent(review.getReviewContent())
                 .reviewer(ReadReviewerResponse.from(review.getReviewSubmission().getReviewer()))
@@ -33,7 +33,7 @@ public class ReadReviewResponse {
                 .branch(review.getReviewSubmission().getBranch())
                 .requestDetails(review.getReviewSubmission().getRequestDetails())
                 .status(review.getReviewSubmission().getStatus())
-                //.fileSystem()
+                .fileSystem(fileSystem)
                 .createdAt(review.getReviewSubmission().getCreatedAt())
                 .updatedAt(review.getReviewSubmission().getUpdatedAt())
                 .build();

--- a/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
@@ -22,7 +22,7 @@ public class ReadReviewSubmissionResponse {
     LocalDateTime createdAt;
     LocalDateTime updatedAt;
 
-    public static ReadReviewSubmissionResponse from(ReviewSubmission reviewSubmission) {
+    public static ReadReviewSubmissionResponse from(ReviewSubmission reviewSubmission, ProjectFileSystem fileSystem) {
 
         BaseAuditResponse baseAuditResponse = BaseAuditResponse.from(reviewSubmission.getCreatedAt());
         return ReadReviewSubmissionResponse.builder()
@@ -33,7 +33,7 @@ public class ReadReviewSubmissionResponse {
                 .branch(reviewSubmission.getBranch())
                 .createdAt(baseAuditResponse.getCreatedAt())
                 .updatedAt(baseAuditResponse.getUpdatedAt())
-                //.fileSystem()
+                .fileSystem(fileSystem)
                 .build();
     }
 }

--- a/src/main/java/konkuk/ptal/service/FileServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/FileServiceImpl.java
@@ -1,132 +1,365 @@
 package konkuk.ptal.service;
 
-import konkuk.ptal.exception.BadRequestException;
-import lombok.extern.slf4j.Slf4j;
-import org.eclipse.jgit.api.CloneCommand;
+import konkuk.ptal.domain.enums.FileNodeType;
+import konkuk.ptal.dto.response.*;
+import konkuk.ptal.entity.CodeFile;
+import konkuk.ptal.exception.EntityNotFoundException;
 import org.eclipse.jgit.api.Git;
+import konkuk.ptal.entity.ReviewSubmission;
+import konkuk.ptal.repository.CodeFileRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.jgit.api.LsRemoteCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.Constants;
+import org.eclipse.jgit.errors.MissingObjectException;
+import org.eclipse.jgit.lib.*;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevTree;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.eclipse.jgit.treewalk.TreeWalk;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-import static konkuk.ptal.dto.api.ErrorCode.*;
+import static konkuk.ptal.dto.api.ErrorCode.ENTITY_NOT_FOUND;
+
 
 @Service
 @Slf4j
+@RequiredArgsConstructor
 public class FileServiceImpl implements IFileService{
+    private final CodeFileRepository codeFileRepository;
 
     @Value("${file.storage.base-path}")
-    private String baseStoragePath;
-
+    private String LOCAL_REPO_BASE_DIR_PREFIX;
+    private final Map<String, Path> localRepoCache = new ConcurrentHashMap<>();
     @Override
-    public String saveCode(String githubAddress, String branchName) {
-
-        String repoName = extractRepoName(githubAddress);
-        if (repoName == null) {
-            throw new BadRequestException(REPO_NAME_EXTRACTION_FAILED);
-        }
-        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
-        Path targetPath = Paths.get(baseStoragePath, repoName + "_" + timestamp);
-        File targetDir = targetPath.toFile();
+    public ListBranchesResponse getBranches(String gitUrl) {
+        File localRepoDir;
         try {
-            if (!targetDir.exists()) {
-                targetDir.mkdirs();
+            String defaultBranchForLocalClone = "main";
+            localRepoDir = getOrCreateLocalRepo(gitUrl, defaultBranchForLocalClone);
+        } catch (IOException | GitAPIException e) {
+            log.error("Failed to prepare local repository for getting branches for {}: {}", gitUrl, e.getMessage());
+            throw new RuntimeException("Failed to prepare local repository for getting branches: " + e.getMessage(), e);
+        }
+
+        try (Git git = Git.open(localRepoDir)) {
+            Repository repository = git.getRepository();
+
+            LsRemoteCommand lsRemote = git.lsRemote();
+            lsRemote.setHeads(true).setTags(false).setRemote(gitUrl);
+
+            Map<String, Ref> refs = (Map<String, Ref>) lsRemote.call();
+            List<GitBranch> branches = new ArrayList<>();
+            String defaultBranchName = Constants.MASTER;
+
+            try (RevWalk revWalk = new RevWalk(repository)) {
+                for (Map.Entry<String, Ref> entry : refs.entrySet()) {
+                    String branchName = Repository.shortenRefName(entry.getKey());
+                    ObjectId commitId = entry.getValue().getObjectId();
+
+                    LocalDateTime lastCommitDate = null;
+                    String lastCommitMessage = null;
+
+                    try {
+                        RevCommit commit = revWalk.parseCommit(commitId);
+                        lastCommitDate = LocalDateTime.ofInstant(
+                                Instant.ofEpochSecond(commit.getCommitTime()), ZoneId.systemDefault());
+                        lastCommitMessage = commit.getFullMessage();
+                    } catch (MissingObjectException e) {
+                        log.warn("Missing object for commit {} in local repository while getting branches: {}", commitId.name(), e.getMessage());
+                    }
+
+                    boolean isDefault = branchName.equals(defaultBranchName);
+
+                    branches.add(GitBranch.from(branchName, isDefault, commitId.name(), lastCommitDate, lastCommitMessage));
+                }
             }
 
-            CloneCommand cloneCommand = Git.cloneRepository()
-                    .setURI(githubAddress)
-                    .setDirectory(targetDir);
+            branches.sort(Comparator.comparing(GitBranch::getName));
 
-            if (branchName != null && !branchName.trim().isEmpty()) {
-                cloneCommand.setBranch(branchName)
-                        .setBranchesToClone(List.of(Constants.R_HEADS + branchName));
-            }
+            return ListBranchesResponse.from(gitUrl, branches, defaultBranchName);
 
-            cloneCommand.call();
-            System.out.println("Repository cloned successfully to: " + targetPath.toAbsolutePath().toString());
-            return targetPath.toAbsolutePath().toString();
-
-        } catch (GitAPIException e) {
-            System.err.println("Error during JGit clone operation: " + e.getMessage());
-            cleanupDirectory(targetPath, targetDir);
-            throw new BadRequestException(REPO_CLONE_FAILED);
-        }
-    }
-
-    private String extractRepoName(String githubAddress) {
-        if (githubAddress == null || githubAddress.trim().isEmpty()) {
-            return null;
-        }
-        int lastSlash = githubAddress.lastIndexOf('/');
-        int lastDotGit = githubAddress.lastIndexOf(".git");
-
-        String name = githubAddress;
-        if (lastSlash != -1) {
-            name = name.substring(lastSlash + 1);
-        }
-        if (lastDotGit != -1) {
-            name = name.substring(0, lastDotGit);
-        }
-        return name.isEmpty() ? null : name;
-    }
-
-    private void cleanupDirectory(Path targetPath, File targetDir) {
-        try {
-            if (targetDir.exists()) {
-                Files.walk(targetPath)
-                        .sorted(java.util.Comparator.reverseOrder())
-                        .map(Path::toFile)
-                        .forEach(File::delete);
-            }
-        } catch (IOException cleanupException) {
-            log.error("Error cleaning up directory {} after failed operation: {}", targetPath.toAbsolutePath(), cleanupException.getMessage(), cleanupException);
+        } catch (GitAPIException | IOException e) {
+            log.error("Failed to get branches for {}: {}", gitUrl, e.getMessage());
+            throw new RuntimeException("Failed to get branches: " + e.getMessage(), e);
         }
     }
 
     @Override
-    public String getCodeFile(String absolutePath, String relativeFilePath) {
-        Path filePath = Paths.get(absolutePath, relativeFilePath);
+    public ProjectFileSystem getProjectFileSystem(String gitUrl, String branch, Long submissionId) {
+        File localRepoDir;
         try {
-            if (Files.exists(filePath) && Files.isReadable(filePath)) {
-                return Files.readString(filePath);
-            } else {
-                System.err.println("File not found or not readable: " + filePath.toAbsolutePath());
-                return null;
+            localRepoDir = getOrCreateLocalRepo(gitUrl, branch);
+        } catch (IOException | GitAPIException e) {
+            throw new RuntimeException("Failed to prepare local repository: " + e.getMessage(), e);
+        }
+
+        try (Git git = Git.open(localRepoDir)) {
+            Repository repository = git.getRepository();
+            ObjectId head = repository.resolve(Constants.HEAD);
+
+            if (head == null) {
+                throw new RuntimeException("HEAD not found for branch: " + branch);
+            }
+
+            try (RevWalk revWalk = new RevWalk(repository)) {
+                RevCommit commit = revWalk.parseCommit(head);
+                RevTree tree = commit.getTree();
+
+                FileNode rootNode = walkTree(git, repository, tree, "");
+
+                Long totalFiles = 0L;
+                Long totalSize = 0L;
+
+                try (TreeWalk treeWalk = new TreeWalk(repository)) {
+                    treeWalk.addTree(tree);
+                    treeWalk.setRecursive(true);
+                    while (treeWalk.next()) {
+                        if (!treeWalk.isSubtree()) {
+                            totalFiles++;
+                            try {
+                                ObjectId blobId = treeWalk.getObjectId(0);
+                                ObjectLoader loader = repository.open(blobId);
+                                totalSize += loader.getSize();
+                            } catch (MissingObjectException e) {
+                                log.warn("Missing object for file {}: {}", treeWalk.getPathString(), e.getMessage());
+                            }
+                        }
+                    }
+                }
+
+                return ProjectFileSystem.from(submissionId, branch, rootNode, totalFiles, totalSize);
+
             }
         } catch (IOException e) {
-            System.err.println("Error reading code file: " + filePath.toAbsolutePath() + " - " + e.getMessage());
-            e.printStackTrace();
-            return null;
+            log.error("Failed to get project file system from {}: {}", gitUrl, e.getMessage());
+            throw new RuntimeException("Failed to get project file system: " + e.getMessage(), e);
+        }
+    }
+
+
+
+    @Override
+    public FileContent getFileContent(String gitUrl, String branch, String filePath) {
+        File localRepoDir;
+        try {
+            localRepoDir = getOrCreateLocalRepo(gitUrl, branch);
+        } catch (IOException | GitAPIException e) {
+            throw new RuntimeException("Failed to prepare local repository: " + e.getMessage(), e);
+        }
+
+        try (Git git = Git.open(localRepoDir)) {
+            Repository repository = git.getRepository();
+            ObjectId head = repository.resolve(Constants.HEAD);
+
+            if (head == null) {
+                throw new RuntimeException("HEAD not found for branch: " + branch);
+            }
+
+            try (RevWalk revWalk = new RevWalk(repository)) {
+                RevCommit commit = revWalk.parseCommit(head);
+                RevTree tree = commit.getTree();
+
+                try (TreeWalk treeWalk = TreeWalk.forPath(repository, filePath, tree)) {
+                    if (treeWalk == null) {
+                        throw new EntityNotFoundException(ENTITY_NOT_FOUND);
+                    }
+
+                    ObjectId blobId = treeWalk.getObjectId(0);
+                    ObjectLoader loader = repository.open(blobId);
+
+                    ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    loader.copyTo(out);
+                    String content = out.toString(StandardCharsets.UTF_8.name());
+
+                    LocalDateTime lastModified = LocalDateTime.ofInstant(
+                            Instant.ofEpochSecond(commit.getCommitTime()), ZoneId.systemDefault());
+
+                    int lineCount = (StandardCharsets.UTF_8.equals(StandardCharsets.UTF_8)) ?
+                            content.split("\r\n|\r|\n").length : 0;
+
+                    return FileContent.from(filePath, content, StandardCharsets.UTF_8.name(), loader.getSize(), lastModified, lineCount);
+                }
+            }
+        } catch (IOException e) {
+            log.error("Failed to get file content for {}: {}", filePath, e.getMessage());
+            throw new RuntimeException("Failed to get file content: " + e.getMessage(), e);
         }
     }
 
     @Override
-    public List<String> getCodeFileList(String absolutePath) {
-        Path rootPath = Paths.get(absolutePath);
-        if (!Files.exists(rootPath) || !Files.isDirectory(rootPath)) {
-            throw new BadRequestException(INVALID_REPO_PATH);
+    @Transactional
+    public void createCodeFilesForSubmission(ReviewSubmission submission) {
+        File localRepoDir;
+        try {
+            localRepoDir = getOrCreateLocalRepo(submission.getGitUrl(), submission.getBranch());
+        } catch (IOException | GitAPIException e) {
+            log.error("Failed to prepare local repo for CodeFile creation: {}", e.getMessage());
+            throw new RuntimeException("Failed to prepare local repo for CodeFile creation: " + e.getMessage(), e);
         }
-        try (Stream<Path> walk = Files.walk(rootPath)) {
-            return walk
-                    .filter(Files::isRegularFile)
-                    .filter(p -> !p.toString().contains(File.separator + ".git" + File.separator))
-                    .filter(p -> !p.toString().contains(File.separator + ".idea" + File.separator))
-                    .map(rootPath::relativize)
-                    .map(Path::toString)
-                    .collect(Collectors.toList());
+
+        try (Git git = Git.open(localRepoDir)) {
+            Repository repository = git.getRepository();
+            ObjectId head = repository.resolve(Constants.HEAD);
+            if (head == null) {
+                throw new RuntimeException("HEAD not found for branch: " + submission.getBranch());
+            }
+
+            try (RevWalk revWalk = new RevWalk(repository)) {
+                RevCommit commit = revWalk.parseCommit(head);
+                RevTree tree = commit.getTree();
+
+                List<CodeFile> codeFilesToSave = new ArrayList<>();
+                try (TreeWalk treeWalk = new TreeWalk(repository)) {
+                    treeWalk.addTree(tree);
+                    treeWalk.setRecursive(true);
+                    while (treeWalk.next()) {
+                        if (!treeWalk.isSubtree()) {
+                            String relativePath = treeWalk.getPathString();
+                            codeFilesToSave.add(CodeFile.createCodeFile(submission, relativePath));
+                        }
+                    }
+                }
+                codeFileRepository.saveAll(codeFilesToSave);
+                log.info("Successfully created {} CodeFile entities for submission {}", codeFilesToSave.size(), submission.getId());
+            }
         } catch (IOException e) {
-            throw new BadRequestException(FILE_LIST_ERROR);
+            log.error("Failed to create CodeFile entities for submission {}: {}", submission.getId(), e.getMessage());
+            throw new RuntimeException("Failed to create CodeFile entities: " + e.getMessage(), e);
         }
+    }
+
+    private File getOrCreateLocalRepo(String gitUrl, String branch) throws IOException, GitAPIException {
+        Path localRepoPath;
+        String repoDirName = generateSafeRepoDirName(gitUrl);
+        Path baseDir = getOrCreateBaseDir();
+
+        localRepoPath = baseDir.resolve(repoDirName);
+
+        File localRepoDir = localRepoPath.toFile();
+
+        if (!localRepoDir.exists()) {
+            log.info("Cloning new repository: {} to {}", gitUrl, localRepoPath);
+            try {
+                Git.cloneRepository()
+                        .setURI(gitUrl)
+                        .setDirectory(localRepoDir)
+                        .setBare(false)
+                        .call();
+            } catch (GitAPIException e) {
+                log.error("Failed to clone repository {}: {}", gitUrl, e.getMessage());
+                throw new RuntimeException("Failed to clone repository: " + gitUrl + " - " + e.getMessage(), e);
+            }
+        } else {
+            log.info("Opening existing repository: {} at {}", gitUrl, localRepoPath);
+            try (Git git = Git.open(localRepoDir)) {
+                log.info("Fetching and checking out branch {} for {}", branch, gitUrl);
+                git.fetch()
+                        // .setCredentialsProvider(credentialsProvider) // Private Repo 시 필요
+                        .call();
+                if (git.getRepository().findRef(Constants.R_HEADS + branch) == null) {
+                    git.checkout()
+                            .setCreateBranch(true)
+                            .setName(branch)
+                            .setStartPoint("origin/" + branch)
+                            .call();
+                } else {
+                    git.checkout().setName(branch).call();
+                }
+            } catch (GitAPIException e) {
+                log.error("Failed to fetch/checkout branch {} for {}: {}", branch, gitUrl, e.getMessage());
+                throw new RuntimeException("Failed to update repository: " + gitUrl + " - " + e.getMessage(), e);
+            }
+        }
+        localRepoCache.put(gitUrl, localRepoPath);
+        return localRepoDir;
+    }
+
+    private String generateSafeRepoDirName(String gitUrl) {
+        String name = gitUrl.replaceAll("[^a-zA-Z0-9.-]", "_");
+        if (name.endsWith(".git")) {
+            name = name.substring(0, name.length() - 4);
+        }
+        return name;
+    }
+
+    private Path getOrCreateBaseDir() throws IOException {
+        // TODO: 운영 환경에서는 특정 고정된 경로를 사용하도록 설정해야 합니다.
+        // TODO: 디스크 공간 관리, 오래된 클론 삭제 등 전략 필요
+        Path baseDir = Paths.get(System.getProperty("java.io.tmpdir")).resolve(LOCAL_REPO_BASE_DIR_PREFIX);
+        if (!Files.exists(baseDir)) {
+            Files.createDirectories(baseDir);
+        }
+        return baseDir;
+    }
+
+    private FileNode walkTree(Git git, Repository repository, RevTree tree, String currentPath) throws IOException {
+        List<FileNode> children = new ArrayList<>();
+
+        try (TreeWalk treeWalk = new TreeWalk(repository)) {
+            treeWalk.addTree(tree);
+            treeWalk.setRecursive(false);
+
+            while (treeWalk.next()) {
+                String entryName = treeWalk.getNameString();
+                String entryPath = currentPath.isEmpty() ? entryName : currentPath + "/" + entryName;
+                ObjectId objectId = treeWalk.getObjectId(0);
+
+                if (treeWalk.isSubtree()) {
+                    try (RevWalk subRevWalk = new RevWalk(repository)) {
+                        RevTree subTree = subRevWalk.parseTree(objectId);
+                        FileNode dirNode = walkTree(git, repository, subTree, entryPath);
+                        dirNode = dirNode.from(entryName, entryPath, FileNodeType.DIRECTORY, null, null, dirNode.getChildren());
+                        children.add(dirNode);
+                    } catch (MissingObjectException e) {
+                        log.warn("Missing tree object for path {}: {}", entryPath, e.getMessage());
+                    }
+                } else {
+                    ObjectLoader loader = repository.open(objectId);
+                    Long fileSize = loader.getSize();
+
+                    LocalDateTime lastModified = null;
+                    try {
+                        Iterable<RevCommit> commits = git.log()
+                                .addPath(entryPath)
+                                .setMaxCount(1)
+                                .call();
+                        if (commits.iterator().hasNext()) {
+                            RevCommit lastFileCommit = commits.iterator().next();
+                            lastModified = LocalDateTime.ofInstant(
+                                    Instant.ofEpochSecond(lastFileCommit.getCommitTime()), ZoneId.systemDefault());
+                        }
+                    } catch (GitAPIException e) {
+                        log.warn("Failed to get last commit for file {}: {}", entryPath, e.getMessage());
+                    }
+
+                    FileNode fileNode = FileNode.from(entryName, entryPath, FileNodeType.FILE, fileSize, lastModified, null);
+                    children.add(fileNode);
+                }
+            }
+        }
+        children.sort(Comparator
+                .comparing((FileNode node) -> node.getType() == FileNodeType.DIRECTORY ? 0 : 1)
+                .thenComparing(FileNode::getName));
+
+        return FileNode.from(currentPath.isEmpty() ? "root" : new File(currentPath).getName(), currentPath, FileNodeType.DIRECTORY, null, null, children);
     }
 }

--- a/src/main/java/konkuk/ptal/service/IFileService.java
+++ b/src/main/java/konkuk/ptal/service/IFileService.java
@@ -1,27 +1,44 @@
 package konkuk.ptal.service;
 
+import konkuk.ptal.dto.response.FileContent;
+import konkuk.ptal.dto.response.ListBranchesResponse;
+import konkuk.ptal.dto.response.ProjectFileSystem;
+import konkuk.ptal.entity.ReviewSubmission;
+
 import java.util.List;
 
 public interface IFileService {
+    /**
+     * 특정 Git URL의 브랜치 목록을 조회합니다.
+     * @param gitUrl 깃허브 저장소 주소
+     * @return 브랜치 목록 정보를 담은 응답 DTO
+     */
+    ListBranchesResponse getBranches(String gitUrl);
 
     /**
-     * 코드 파일을 깃허브로부터 다운로드 받아서 저장합니다.
-     * @param githubAddress 깃허브 주소
+     * 특정 Git 저장소와 브랜치의 파일 시스템 구조(트리 형태)를 조회합니다.
+     * @param gitUrl 깃허브 저장소 주소
+     * @param branch 대상 브랜치 이름
+     * @param submissionId (옵션) ReviewSubmission ID. ProjectFileSystem DTO에 포함될 정보.
+     * @return 프로젝트 파일 시스템 구조를 담은 응답 DTO
      */
-    String saveCode(String githubAddress, String branchName);
+    ProjectFileSystem getProjectFileSystem(String gitUrl, String branch, Long submissionId);
 
     /**
-     * 특정 코드파일을 조회하기 위해 사용합니다.
-     * @param absolutePath 코드가 저장되어있는 절대경로(프로젝트 루트까지의 경로)
-     * @param relativeFilePath 절대경로 뒤로 붙는 상대경로
+     * 특정 Git 저장소와 브랜치 내 특정 파일의 내용을 조회합니다.
+     * @param gitUrl 깃허브 저장소 주소
+     * @param branch 대상 브랜치 이름
+     * @param filePath 조회할 파일의 저장소 내 상대 경로
+     * @return 파일 내용을 담은 응답 DTO
      */
-    String getCodeFile(String absolutePath, String relativeFilePath);
+    FileContent getFileContent(String gitUrl, String branch, String filePath);
 
     /**
-     * 모든 코드 파일을 조회하기 위해 사용합니다.
-     * @param absolutePath 코드가 저장되어있는 절대경로(프로젝트 루트까지의 경로)
-     * @return 상대경로 목록을 반환합니다. (java.util.List)
+     * ReviewSubmission 생성 시, 해당 Git 저장소의 모든 파일 경로를 스캔하여 CodeFile 엔티티로 변환 후 DB에 저장합니다.
+     * 이 메서드는 ReviewSubmissionService에서 호출되어야 합니다.
+     * @param submission CodeFile 엔티티를 생성할 대상 ReviewSubmission 엔티티
      */
-    List<String> getCodeFileList(String absolutePath);
+    void createCodeFilesForSubmission(ReviewSubmission submission);
+
 
 }

--- a/src/main/java/konkuk/ptal/service/IReviewService.java
+++ b/src/main/java/konkuk/ptal/service/IReviewService.java
@@ -7,6 +7,7 @@ import konkuk.ptal.dto.request.CreateReviewRequest;
 import konkuk.ptal.dto.request.CreateReviewSubmissionRequest;
 import konkuk.ptal.dto.request.UpdateReviewRequest;
 import konkuk.ptal.dto.request.UpdateReviewCommentRequest;
+import konkuk.ptal.dto.response.ListReviewSubmissionResponse;
 import konkuk.ptal.dto.response.ListReviewsResponse;
 import konkuk.ptal.dto.response.ReadReviewResponse;
 import konkuk.ptal.dto.response.ReadCommentsOfReviewResponse;
@@ -45,7 +46,7 @@ public interface IReviewService {
      * @param userPrincipal 현재 인증된 사용자 정보
      * @return 필터링 및 페이지네이션된 리뷰 제출 목록 DTO
      */
-    Page<ReviewSubmission> getReviewSubmissions(ReviewSubmissionType type, int page, int size, UserPrincipal userPrincipal);
+    ListReviewSubmissionResponse getReviewSubmissions(ReviewSubmissionType type, int page, int size, UserPrincipal userPrincipal);
 
     /**
      * 특정 리뷰 제출(요청)을 취소합니다.
@@ -111,5 +112,5 @@ public interface IReviewService {
     Review updateReview(Long reviewId, UpdateReviewRequest request, UserPrincipal userPrincipal);
 
     // 리뷰 목록 조회
-    Page<Review> getReviews(Long submissionId, Long reviewerId, Long revieweeId, int page, int size, UserPrincipal userPrincipal);
+    ListReviewsResponse getReviews(Long submissionId, Long reviewerId, Long revieweeId, int page, int size, UserPrincipal userPrincipal);
 }


### PR DESCRIPTION
### 주요 변경 사항
- `ReadReviewSubmissionResponse`, `ReadReviewResponse` 과 관련된 로직들이  `ProjectFileSystem` 추가로 인해 수정됨.
- spec에 따라 fileservice 구현체 업데이트

### Note 
- fileservice 내부 로직이 많이 복잡하여 상세한 검증이 필요해보임.
- `ReviewServiceImpl`의 `getReviewSubmissions` , `getReviews`의 경우 `ProjectFileSystem` 추가로 인해  메서드에서 각 `ReviewSubmission` 또는 `Review` 항목에 대해 `ProjectFileSystem`을 조회하기 위해 `fileService.getProjectFileSystem()`을 개별적으로 호출함. 이에 따라 `N+1`문제가 발생할 우려가 있어서 검증 시 성능 저하 문제가 발생하면 전체적인 구조 개선이 필요할 수 있음.