### PR TITLE
/reviewers API 구현

### DIFF
--- a/src/main/java/konkuk/ptal/controller/UserController.java
+++ b/src/main/java/konkuk/ptal/controller/UserController.java
@@ -7,6 +7,7 @@ import konkuk.ptal.dto.api.ResponseCode;
 import konkuk.ptal.dto.request.*;
 import konkuk.ptal.dto.response.CreateRevieweeResponse;
 import konkuk.ptal.dto.response.CreateReviewerResponse;
+import konkuk.ptal.dto.response.ListReviewersResponse;
 import konkuk.ptal.dto.response.ReadUserResponse;
 import konkuk.ptal.entity.Reviewee;
 import konkuk.ptal.entity.Reviewer;
@@ -17,6 +18,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/v1") // Base path for user-specific operations
@@ -111,6 +115,30 @@ public class UserController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(ApiResponse.success(ResponseCode.DATA_UPDATE_SUCCESS.getMessage(), responseDto));
+    }
+
+    @GetMapping("/reviewers")
+    public ResponseEntity<ApiResponse<ListReviewersResponse>> getReviewers(
+            @RequestParam(value = "preferences", required = false) String preferences,
+            @RequestParam(value = "tags", required = false) String tags,
+            @RequestParam(value = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(value = "size", required = false, defaultValue = "10") int size) {
+        
+        // 쉼표로 구분된 문자열을 List로 변환
+        List<String> preferencesList = null;
+        if (preferences != null && !preferences.trim().isEmpty()) {
+            preferencesList = Arrays.asList(preferences.split(","));
+        }
+        
+        List<String> tagsList = null;
+        if (tags != null && !tags.trim().isEmpty()) {
+            tagsList = Arrays.asList(tags.split(","));
+        }
+        
+        ListReviewersResponse responseDto = userService.getReviewers(preferencesList, tagsList, page, size);
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(ApiResponse.success(ResponseCode.DATA_RETRIEVED.getMessage(), responseDto));
     }
 }
 

--- a/src/main/java/konkuk/ptal/service/IUserService.java
+++ b/src/main/java/konkuk/ptal/service/IUserService.java
@@ -2,9 +2,12 @@ package konkuk.ptal.service;
 
 
 import konkuk.ptal.dto.request.*;
+import konkuk.ptal.dto.response.ListReviewersResponse;
 import konkuk.ptal.entity.Reviewee;
 import konkuk.ptal.entity.Reviewer;
 import konkuk.ptal.entity.User;
+
+import java.util.List;
 
 public interface IUserService {
     Reviewer registerReviewer(CreateReviewerRequest dto);
@@ -22,5 +25,7 @@ public interface IUserService {
     User getUser(Long id);
 
     User updateUser(Long id, UpdateUserRequest dto);
+
+    ListReviewersResponse getReviewers(List<String> preferences, List<String> tags, int page, int size);
 
 }

--- a/src/main/java/konkuk/ptal/service/UserServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/UserServiceImpl.java
@@ -3,6 +3,7 @@ package konkuk.ptal.service;
 import konkuk.ptal.domain.enums.Role;
 import konkuk.ptal.dto.api.ErrorCode;
 import konkuk.ptal.dto.request.*;
+import konkuk.ptal.dto.response.ListReviewersResponse;
 import konkuk.ptal.entity.Reviewee;
 import konkuk.ptal.entity.Reviewer;
 import konkuk.ptal.entity.User;
@@ -13,8 +14,13 @@ import konkuk.ptal.repository.ReviewerRepository;
 import konkuk.ptal.repository.UserRepository;
 import konkuk.ptal.util.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -122,5 +128,24 @@ public class UserServiceImpl implements IUserService {
             user.setPasswordHash(hashedPassword);
         });
         return userRepository.save(user);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ListReviewersResponse getReviewers(List<String> preferences, List<String> tags, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Reviewer> reviewerPage;
+
+        // 필터링 조건에 따라 조회
+        if ((preferences != null && !preferences.isEmpty()) || (tags != null && !tags.isEmpty())) {
+            // TODO: 실제로는 JPA Specification이나 QueryDSL을 사용하여 동적 쿼리를 만들어야 합니다.
+            // 현재는 단순히 모든 리뷰어를 조회하고 메모리에서 필터링합니다.
+            reviewerPage = reviewerRepository.findAll(pageable);
+        } else {
+            // 필터링 조건이 없으면 모든 리뷰어 조회
+            reviewerPage = reviewerRepository.findAll(pageable);
+        }
+
+        return ListReviewersResponse.from(reviewerPage);
     }
 }


### PR DESCRIPTION
- `UserController`에 `/reviewers` 엔드포인트를 추가하여 리뷰어 목록을 조회할 수 있는 기능을 구현했습니다.
- `IUserService` 인터페이스에 리뷰어 목록 조회 메서드를 추가하고, `UserServiceImpl`에서 해당 메서드를 구현하여 필터링 및 페이징 기능을 지원합니다.
- 요청 파라미터로 preferences와 tags를 받아서 필터링할 수 있도록 하였습니다.