### PR TITLE
fix: Git 브랜치 조회 로직 수정

### DIFF
--- a/src/main/java/konkuk/ptal/service/FileServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/FileServiceImpl.java
@@ -31,10 +31,7 @@ import java.nio.file.Paths;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 import static konkuk.ptal.dto.api.ErrorCode.ENTITY_NOT_FOUND;
@@ -67,14 +64,14 @@ public class FileServiceImpl implements IFileService {
             LsRemoteCommand lsRemote = git.lsRemote();
             lsRemote.setHeads(true).setTags(false).setRemote(gitUrl);
 
-            Map<String, Ref> refs = (Map<String, Ref>) lsRemote.call();
+            Collection<Ref> refs = lsRemote.call();
             List<GitBranchResponse> branches = new ArrayList<>();
             String defaultBranchName = Constants.MASTER;
 
             try (RevWalk revWalk = new RevWalk(repository)) {
-                for (Map.Entry<String, Ref> entry : refs.entrySet()) {
-                    String branchName = Repository.shortenRefName(entry.getKey());
-                    ObjectId commitId = entry.getValue().getObjectId();
+                for (Ref ref : refs) {
+                    String branchName = Repository.shortenRefName(ref.getName());
+                    ObjectId commitId = ref.getObjectId();
 
                     LocalDateTime lastCommitDate = null;
                     String lastCommitMessage = null;


### PR DESCRIPTION
## 관련 issue

resolves #60 

## 문제 원인 요약:

- JGit의 LsRemoteCommand.call() 메서드는 Collection<Ref>를 반환합니다
- 기존 코드에서는 이를 Map<String, Ref>로 잘못 캐스팅하려고 했습니다
    - HashMap$Values는 Map 인터페이스를 구현하지 않기 때문에 ClassCastException이 발생했습니다
- 올바른 방법은 Collection<Ref>로 받아서 각 Ref 객체에서 직접 정보를 추출하는 것입니다