### PR TITLE
fix: 리뷰 제출 컨트롤러의 요청 파라미터 기본값을 'ALL'로 변경

### DIFF
--- a/src/main/java/konkuk/ptal/config/WebConfig.java
+++ b/src/main/java/konkuk/ptal/config/WebConfig.java
@@ -10,10 +10,10 @@ import java.util.List;
 
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
+
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
         StringHttpMessageConverter stringConverter = new StringHttpMessageConverter(StandardCharsets.UTF_8);
         converters.add(stringConverter);
     }
-
 }

--- a/src/main/java/konkuk/ptal/controller/ReviewSubmissionController.java
+++ b/src/main/java/konkuk/ptal/controller/ReviewSubmissionController.java
@@ -43,7 +43,7 @@ public class ReviewSubmissionController {
 
     @GetMapping("/review-submissions")
     public ResponseEntity<ApiResponse<ListReviewSubmissionResponse>> getReviewSubmissions(
-            @RequestParam(name = "type", required = false, defaultValue = "all") ReviewSubmissionType type,
+            @RequestParam(name = "type", required = false, defaultValue = "ALL") ReviewSubmissionType type,
             @RequestParam(name = "page", required = false, defaultValue = "0") int page,
             @RequestParam(name = "size", required = false, defaultValue = "10") int size,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {


### PR DESCRIPTION
## 관련 이슈

resolves #59 

## 해결방법

기본값이 "all"로 설정되어 있었는데, "ALL"로 설정해야 java ENUM 타입으로 자동변환되므로 대문자로 변경했습니다.

이 문제가 반복되면 MVP에서는 Frontend에서 대문자로 요청하는 방법으로 일시적으로 진행하되, 대소문자 컨버터를 커스터마이즈하여 추가하는 것이 좋겠습니다.