### PR TITLE
feat: Implement BlackList Token

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY --from=build /app/build/libs/*.jar app.jar
 
 # Set environment variables
 ENV JAVA_OPTS="-Xmx512m -Xms256m"
-ENV SPRING_PROFILES_ACTIVE="prod"
+# ENV SPRING_PROFILES_ACTIVE="prod"
 
 # Expose the application port
 EXPOSE 8080

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
     // https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit
     implementation("org.eclipse.jgit:org.eclipse.jgit:7.2.1.202505142326-r")
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.8'
+
+services:
+  # Spring Boot Application Service
+  app:
+    build:
+      context: . # Dockerfile이 있는 현재 디렉토리를 빌드 컨텍스트로 사용
+      dockerfile: Dockerfile # Dockerfile의 이름
+    ports:
+      - "8080:8080" # 호스트 포트:컨테이너 포트
+    environment:
+      JAVA_OPTS: "-Xmx512m -Xms256m"
+      # SPRING_PROFILES_ACTIVE: "prod"
+      # Redis 연결 정보 (환경 변수로 전달)
+      # Spring Data Redis는 이 환경 변수를 자동으로 인식합니다.
+      SPRING_DATA_REDIS_HOST: redis
+      SPRING_DATA_REDIS_PORT: 6379
+      JWT_SECRET_KEY: YmFzZTY0ZW5jb2RlZHNlY3JldGtleXN0cmluZ2hlcmU=
+       # H2 Console (개발용) - 필요하다면 추가
+      SPRING_H2_CONSOLE_ENABLED: true
+      SPRING_H2_CONSOLE_PATH: /h2-console
+      SPRING_DATASOURCE_URL: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+      SPRING_DATASOURCE_DRIVER_CLASS_NAME: org.h2.Driver
+      SPRING_DATASOURCE_USERNAME: sa
+      SPRING_DATASOURCE_PASSWORD:
+    depends_on:
+      - redis # app 서비스는 redis 서비스가 시작된 후에 시작됨
+    networks:
+      - my-app-network # 사용자 정의 네트워크 사용
+
+  # Redis Service
+  redis:
+    image: redis:latest # 최신 Redis 이미지 사용
+    ports:
+      - "6379:6379" # 호스트 포트:컨테이너 포트 (선택 사항, 내부 통신만 한다면 굳이 외부에 노출할 필요는 없음)
+    command: redis-server --appendonly yes # 데이터 영속성을 위해 AOF 설정
+    networks:
+      - my-app-network # 사용자 정의 네트워크 사용
+
+networks:
+  my-app-network:
+    driver: bridge # 기본 브리지 네트워크

--- a/src/main/java/konkuk/ptal/config/RedisConfig.java
+++ b/src/main/java/konkuk/ptal/config/RedisConfig.java
@@ -1,0 +1,39 @@
+package konkuk.ptal.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    /**
+     * RedisTemplate Bean을 등록합니다.
+     * 키와 값의 직렬화 방식을 설정하여 Redis에 데이터를 저장하고 조회할 때 문제가 없도록 합니다.
+     * StringRedisSerializer: Key를 String으로 직렬화 (가독성 좋음)
+     * GenericJackson2JsonRedisSerializer: Value를 JSON 형태로 직렬화 (객체 저장 시 유용)
+     *
+     * @param redisConnectionFactory Redis 연결 팩토리 (Spring Boot가 자동 설정)
+     * @return 설정된 RedisTemplate 객체
+     */
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory); // Redis 연결 팩토리 설정
+
+        // Key 직렬화 설정 (String)
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        // Value 직렬화 설정 (JSON)
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        // Hash Key 직렬화 설정 (String) - Redis Hash 타입을 사용할 경우
+        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
+        // Hash Value 직렬화 설정 (JSON) - Redis Hash 타입을 사용할 경우
+        redisTemplate.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        redisTemplate.afterPropertiesSet(); // 직렬화 설정 후 초기화
+        return redisTemplate;
+    }
+}

--- a/src/main/java/konkuk/ptal/config/SecurityConfig.java
+++ b/src/main/java/konkuk/ptal/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package konkuk.ptal.config;
 
 import konkuk.ptal.service.CustomUserDetailsService;
+import konkuk.ptal.service.TokenBlacklistService;
 import konkuk.ptal.util.PasswordEncoder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -27,6 +28,7 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
     private final CustomUserDetailsService userDetailsService;
+    private final TokenBlacklistService tokenBlacklistService;
 
     // Swagger UI 및 OpenAPI 문서 접근을 위한 경로 정의 (JwtAuthenticationFilter에서도 사용 가능하도록 public static으로)
     public static final String[] SWAGGER_PATHS = {
@@ -52,14 +54,18 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/auth/signup/reviewee").permitAll()
                         .requestMatchers("/api/v1/auth/signin").permitAll()
                         .requestMatchers("/api/v1/auth/signout").authenticated()
+                        .requestMatchers("api/v1/auth/refresh").authenticated()
                         .requestMatchers("/h2-console/**").permitAll()
                         .requestMatchers(SWAGGER_PATHS).permitAll() // Swagger 경로 허용
                         .requestMatchers("/api/v1/reviewer/**").authenticated()
                         .requestMatchers("/api/v1/reviewee/**").authenticated()
                         .requestMatchers("/api/v1/reviews/**").authenticated()
+                        .requestMatchers("/api/v1/users/**").authenticated()
+                        .requestMatchers("/api/v1/review-comments/**").authenticated()
+                        .requestMatchers("/api/v1/review-submissions/**").authenticated()
                         .anyRequest().authenticated()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, tokenBlacklistService), UsernamePasswordAuthenticationFilter.class); // 수정
         http.headers().frameOptions().sameOrigin();
         return http.build();
     }

--- a/src/main/java/konkuk/ptal/service/IAuthenticationService.java
+++ b/src/main/java/konkuk/ptal/service/IAuthenticationService.java
@@ -8,6 +8,5 @@ public interface IAuthenticationService {
     AuthTokenResponse login(UserLoginRequest dto);
 
     AuthTokenResponse refreshAccessToken(RefreshTokenRequest dto);
-
-    void logout(String email);
+    void logout(String email, String accessToken);
 }

--- a/src/main/java/konkuk/ptal/service/TokenBlacklistService.java
+++ b/src/main/java/konkuk/ptal/service/TokenBlacklistService.java
@@ -1,0 +1,60 @@
+package konkuk.ptal.service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.security.Key;
+import java.util.concurrent.TimeUnit;
+
+@Service
+public class TokenBlacklistService {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final String BLACKLIST_PREFIX = "jwt:blacklist:";
+    private final Key secretKey;
+
+    public TokenBlacklistService(RedisTemplate<String, Object> redisTemplate,
+                                 @Value("${jwt.secret}") String secretKeyString) {
+        this.redisTemplate = redisTemplate;
+        byte[] keyBytes = Decoders.BASE64.decode(secretKeyString);
+        this.secretKey = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public void addTokenToBlacklist(String token, long expirationTimeMillis) {
+        String key = BLACKLIST_PREFIX + token;
+
+        long currentTimeMillis = System.currentTimeMillis();
+        long remainingExpirationTimeSeconds = (expirationTimeMillis - currentTimeMillis) / 1000;
+
+        if (remainingExpirationTimeSeconds > 0) {
+            redisTemplate.opsForValue().set(key, "blacklisted", remainingExpirationTimeSeconds, TimeUnit.SECONDS);
+            System.out.println("블랙리스트에 토큰 추가됨: " + key + ", 남은 시간(초): " + remainingExpirationTimeSeconds);
+        } else {
+            System.out.println("만료된 토큰이므로 블랙리스트에 추가하지 않음: " + key);
+        }
+    }
+
+    public boolean isTokenBlacklisted(String token) {
+        String key = BLACKLIST_PREFIX + token;
+        return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+    }
+
+    private String extractJtiFromToken(String token) {
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(secretKey)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return claims.getId();
+        } catch (Exception e) {
+            System.out.println("토큰에서 Jti 추출 실패");
+            return null;
+        }
+
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -27,7 +27,8 @@ logging:
 # JWT 설정
 jwt:
   secret: YmFzZTY0ZW5jb2RlZHNlY3JldGtleXN0cmluZ2hlcmU=
-  expiration: 86400000
+  access-token-expiration-ms: 3600000
+  refresh-token-expiration-ms: 604800000
   header: Authorization
   prefix: Bearer
 
@@ -48,3 +49,23 @@ springdoc:
 file:
   storage:
     base-path: src/main/resources/code_storage
+
+  # --- Redis 설정 시작 ---
+  data:
+    redis:
+      # 호스트: Docker Compose 환경에서는 'redis' 서비스 이름으로 컨테이너에 접근
+      #         로컬에서 Redis를 직접 띄웠을 때는 'localhost'로 연결
+      host: localhost
+      # 포트: Redis 기본 포트 6379
+      port: 6379
+
+      # password: ${SPRING_DATA_REDIS_PASSWORD:} # Redis에 비밀번호가 있다면 여기에 설정 (환경 변수 또는 직접 입력)
+      # ssl: false # SSL/TLS를 사용하지 않는 경우 (기본값)
+      # timeout: 2000ms # 연결 타임아웃 (선택 사항)
+      # lettuce: # Lettuce 클라이언트 설정 (선택 사항)
+      #   pool:
+      #     max-active: 8 # 풀에서 생성할 수 있는 최대 연결 수
+      #     min-idle: 0   # 유휴 상태로 유지할 수 있는 최소 연결 수
+      #     max-idle: 8   # 유휴 상태로 유지할 수 있는 최대 연결 수
+      #     max-wait: -1ms # 풀에서 연결을 사용할 수 있을 때까지 블록 시간 (ms, -1은 무한대)
+  # --- Redis 설정 끝 ---


### PR DESCRIPTION
### 해결하려는 문제:

기존에는 사용자 로그아웃 및 토큰 갱신 시에도 액세스 토큰이 만료 시간까지 유효하여 재사용될 수 있는 보안 취약점이 있었습니다.

### 해결 방법:

1.  **로그아웃 시:** 사용 중이던 액세스 토큰을 Redis 블랙리스트에 등록하여 즉시 무효화합니다.
2.  **인증 필터(`JwtAuthenticationFilter`)에서:** 모든 인증 요청 시 Redis 블랙리스트를 확인하여 등록된 토큰은 접근을 차단합니다.
3.  **토큰 갱신 시:** 이전 리프레시 토큰을 무효화하는 로직을 추가하여 보안을 강화합니다.

### Related to:
- #57 

### Note:

Redis 의존성이 추가되었으므로, `docker-compose up --build` 명령어로 실행해야 합니다.

<img width="1368" alt="스크린샷 2025-06-07 오후 10 24 32" src="https://github.com/user-attachments/assets/ee9c1606-faa1-4dca-9d90-9189719c501e" />

<img width="936" alt="스크린샷 2025-06-07 오후 10 24 56" src="https://github.com/user-attachments/assets/d581f829-6046-4249-a844-352eb2cb5fe0" />
