### PR TITLE
feat: 리뷰 제출 응답 DTO에 요청 세부정보 및 상태 추가

### DIFF
--- a/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
@@ -31,6 +31,8 @@ public class ReadReviewSubmissionResponse {
                 .reviewee(ReadRevieweeResponse.from(reviewSubmission.getReviewee()))
                 .gitUrl(reviewSubmission.getGitUrl())
                 .branch(reviewSubmission.getBranch())
+                .requestDetails(reviewSubmission.getRequestDetails())
+                .status(reviewSubmission.getStatus())
                 .createdAt(baseAuditResponse.getCreatedAt())
                 .updatedAt(baseAuditResponse.getUpdatedAt())
                 .fileSystem(fileSystem)

--- a/src/main/java/konkuk/ptal/entity/ReviewSubmission.java
+++ b/src/main/java/konkuk/ptal/entity/ReviewSubmission.java
@@ -67,6 +67,7 @@ public class ReviewSubmission {
                 .reviewee(reviewee)
                 .reviewer(reviewer)
                 .gitUrl(dto.getGitUrl())
+                .branch(dto.getBranch())
                 .status(status)
                 .build();
     }

--- a/src/main/java/konkuk/ptal/service/FileServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/FileServiceImpl.java
@@ -344,8 +344,10 @@ public class FileServiceImpl implements IFileService {
                                 .call();
                         if (commits.iterator().hasNext()) {
                             RevCommit lastFileCommit = commits.iterator().next();
-                            lastModified = LocalDateTime.ofInstant(
-                                    Instant.ofEpochSecond(lastFileCommit.getCommitTime()), ZoneId.systemDefault());
+                            if (lastFileCommit != null) {
+                                lastModified = LocalDateTime.ofInstant(
+                                        Instant.ofEpochSecond(lastFileCommit.getCommitTime()), ZoneId.systemDefault());
+                            }
                         }
                     } catch (GitAPIException e) {
                         log.warn("Failed to get last commit for file {}: {}", entryPath, e.getMessage());


### PR DESCRIPTION
## 관련 issue

resolves #58 

## 문제점
POST `/api/v1/review-submissions/new` API에서 두 가지 심각한 에러가 발생:

1. **데이터베이스 제약조건 위반**: `branch` 필드가 NULL로 저장되어 에러 발생
2. **NullPointerException**: 파일 시스템 처리 중 커밋 정보가 없는 파일에서 NPE 발생

## 해결 방법

#### 1. ReviewSubmission 생성 시 branch 필드 누락 수정
**파일**: `src/main/java/konkuk/ptal/entity/ReviewSubmission.java`
- `createReviewSubmission()` 메서드에서 `branch(dto.getBranch())` 추가
- 요청 데이터의 branch 값이 정상적으로 데이터베이스에 저장되도록 수정

#### 2. 파일 커밋 정보 null 체크 추가  
**파일**: `src/main/java/konkuk/ptal/service/FileServiceImpl.java`
- `walkTree()` 메서드에서 `lastFileCommit != null` 체크 추가
- 커밋 히스토리가 없는 파일에 대한 안전한 처리

#### 3. 응답 DTO 누락 필드 보완
**파일**: `src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java`  
- `requestDetails`, `status` 필드를 응답에 포함하도록 수정