### PR TITLE
refactor: Fix file path problem

### DIFF
--- a/src/main/java/konkuk/ptal/config/SecurityConfig.java
+++ b/src/main/java/konkuk/ptal/config/SecurityConfig.java
@@ -11,10 +11,13 @@ import org.springframework.security.config.annotation.authentication.configurati
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.firewall.HttpFirewall;
+import org.springframework.security.web.firewall.StrictHttpFirewall;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.CorsUtils;
@@ -41,7 +44,7 @@ public class SecurityConfig {
             "/webjars/**",
             "/favicon.ico"
     };
-
+    
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http

--- a/src/main/java/konkuk/ptal/dto/api/ErrorCode.java
+++ b/src/main/java/konkuk/ptal/dto/api/ErrorCode.java
@@ -25,8 +25,8 @@ public enum ErrorCode {
     PARENT_COMMENT_NOT_BELONG_TO_SESSION("부모 댓글이 세션에 속하지 않습니다."),
     SUBMISSION_CANCEL_UNAVAILABLE("이미 진행 중이거나 취소된 리뷰 제출은 취소할 수 없습니다."),
     REVIEW_ALREADY_EXIST("이미 리뷰가 작성된 제출 건입니다."),
-    REVIEW_UNAVAILABLE("이미 리뷰가 완료되었거나, 취소된 제출 건에는 리뷰를 작성할 수 없습니다.");
-
+    REVIEW_UNAVAILABLE("이미 리뷰가 완료되었거나, 취소된 제출 건에는 리뷰를 작성할 수 없습니다."),
+    NOT_PERMITTED_FILE_PATH("허용되지 않는 파일 경로입니다.");
 
     private final String message;
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,6 +15,11 @@ spring:
     hibernate:
       ddl-auto: update
     show-sql: true
+  mvc:
+    pathmatch:
+      url-decode: true
+      use-trailing-slash-match: true
+      matching-strategy: path_pattern_parser
 # 로깅 설정
 logging:
   level:
@@ -23,6 +28,7 @@ logging:
     konkuk.ptal: DEBUG
   pattern:
     console: "%d{yyyy-MM-dd HH:mm:ss} - %msg%n"
+
 
 # JWT 설정
 jwt:
@@ -44,7 +50,6 @@ springdoc:
     # path: /my-api-docs # API 스펙 JSON/YAML 제공 경로 변경 (선택 사항)
   # 기본적으로 springdoc은 어노테이션 기반으로 API 문서를 생성.
   # 위 url 설정은 Swagger UI가 '추가적으로' 또는 '대체하여' 참조할 파일을 지정하는 것.
-
 # code file 저장소
 file:
   storage:

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -2661,7 +2661,7 @@ paths:
               example:
                 message: "해당 ID의 리뷰 제출 건을 찾을 수 없습니다."
 
-  /review-submissions/{submissionId}/files/{filePath}:
+  /review-submissions/{submissionId}/files:  # filePath가 경로에서 제거됩니다.
     get:
       tags:
         - "파일 시스템 (File System)"
@@ -2670,6 +2670,7 @@ paths:
         리뷰 제출 건의 특정 파일 내용을 조회합니다.
 
         **⚠️ 중요사항:**
+        - 파일 또는 디렉토리 경로는 `path` 쿼리 파라미터로 전달됩니다.
         - 파일 경로는 반드시 URL 인코딩이 필요합니다
         - 슬래시(/)는 %2F로 인코딩해야 합니다
         - 예시: `src/main/java/UserService.java` → `src%2Fmain%2Fjava%2FUserService.java`


### PR DESCRIPTION
### Related to:
- #66 

### 주요 변경 사항
- `/review-submissions/{submissionId}/files`:  filePath가 경로에서 제거됩니다.
- 파일 또는 디렉토리 경로는 `path` 쿼리 파라미터로 전달됩니다.
- 파일 경로는 반드시 URL 인코딩이 필요합니다

<img width="927" alt="스크린샷 2025-06-08 오전 2 50 45" src="https://github.com/user-attachments/assets/878e1aaf-8904-4e48-8702-a07b7db57832" />
