### PR TITLE
fix: github에서 clone한 코드파일이 파일시스템에는 저장되지만 DB에 저장되지 않는 오류 수정

### DIFF
--- a/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
@@ -48,6 +48,8 @@ public class ReviewServiceImpl implements IReviewService {
         ReviewSubmission reviewSubmission = ReviewSubmission.createReviewSubmission(ReviewSubmissionStatus.PENDING, reviewer, reviewee, request);
         reviewSubmission = reviewSubmissionRepository.save(reviewSubmission);
 
+        fileService.createCodeFilesForSubmission(reviewSubmission);
+
         return reviewSubmission;
     }
 


### PR DESCRIPTION
## 문제점

DB에 스키마 메타데이터를 저장하는 코드를 호출하지 않음

## 결과

이제는 코드파일에 댓글이 올바르게 작성되고 있습니다.

<img width="1552" alt="image" src="https://github.com/user-attachments/assets/d9f0de7e-95f2-486b-ad0b-a40f5a3d81a6" />