### PR TITLE
코드파일에 달린 댓글이 로딩되지 않는 문제 수정

### DIFF
--- a/.github/ISSUE_TEMPLATE/default.md
+++ b/.github/ISSUE_TEMPLATE/default.md
@@ -1,0 +1,11 @@
+---
+name: issue-template
+about: 이슈 등록은 아래 양식을 따라주세요.
+title: '[issue] '
+---
+
+## 개요
+
+## 문제점
+
+## 수정제안

--- a/src/main/java/konkuk/ptal/DemoDataInitializer.java
+++ b/src/main/java/konkuk/ptal/DemoDataInitializer.java
@@ -55,8 +55,8 @@ public class DemoDataInitializer implements ApplicationRunner {
     // 댓글 설정
     private static final String SESSION_COMMENT_CONTENT = "프로젝트 전반적으로 잘 구성되어 있네요! 특히 Spring Boot의 자동 설정 부분이 인상적입니다. 몇 가지 세부사항에 대해 코멘트 남겨드릴게요.";
     private static final String CODE_COMMENT_CONTENT = "이 부분의 예외 처리를 좀 더 구체적으로 하면 어떨까요? 현재는 일반적인 Exception을 catch하고 있는데, 특정 예외 타입별로 다른 처리를 하면 더 좋을 것 같습니다.";
-    private static final String CODE_FILE_PATH = "src/main/java/konkuk/ptal/service/ReviewServiceImpl.java";
-    private static final int CODE_LINE_NUMBER = 156;
+    private static final String CODE_FILE_PATH = "src/main/java/konkuk/ptal/PtalApplication.java";
+    private static final int CODE_LINE_NUMBER = 10;
     private static final String REPLY_COMMENT_CONTENT = "피드백 감사합니다! 말씀해주신 예외 처리 부분은 다음 버전에서 반영하겠습니다. 구체적으로 어떤 예외 타입들을 고려하면 좋을지 조언해주실 수 있나요?";
 
     // =================================

--- a/src/main/java/konkuk/ptal/controller/ReviewCommentController.java
+++ b/src/main/java/konkuk/ptal/controller/ReviewCommentController.java
@@ -25,10 +25,11 @@ public class ReviewCommentController {
     @GetMapping("/review-submissions/{submissionId}/comments")
     public ResponseEntity<ApiResponse<ReadCommentsOfReviewResponse>> getReviewComments(
             @PathVariable Long submissionId,
+            @RequestParam(required = false) String filePath,
             @AuthenticationPrincipal UserPrincipal userPrincipal) {
         authorizationService.validateReviewSubmissionAccess(submissionId, userPrincipal);
 
-        ReadCommentsOfReviewResponse response = reviewService.getReviewComments(submissionId, null);
+        ReadCommentsOfReviewResponse response = reviewService.getReviewComments(submissionId, filePath);
         return ResponseEntity.ok(ApiResponse.success("댓글 조회 성공", response));
     }
 

--- a/src/main/java/konkuk/ptal/service/IReviewService.java
+++ b/src/main/java/konkuk/ptal/service/IReviewService.java
@@ -70,10 +70,10 @@ public interface IReviewService {
      * 댓글은 스레드를 나타내는 계층적 구조로 반환됩니다.
      *
      * @param submissionId 리뷰 세션의 고유 식별자입니다.
-     * @param codeFileId   댓글을 조회할 코드 파일의 고유 식별자입니다.
+     * @param codeFile   댓글을 조회할 코드 파일의 상대경로입니다.
      *                     세션 레벨 댓글을 조회하려면 null일 수 있습니다.
      */
-    ReadCommentsOfReviewResponse getReviewComments(Long submissionId, Long codeFileId);
+    ReadCommentsOfReviewResponse getReviewComments(Long submissionId, String codeFile);
 
     /**
      * 기존 댓글을 업데이트합니다.

--- a/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
@@ -170,10 +170,10 @@ public class ReviewServiceImpl implements IReviewService {
 
     @Override
     @Transactional(readOnly = true)
-    public ReadCommentsOfReviewResponse getReviewComments(Long submissionId, Long codeFileId) {
+    public ReadCommentsOfReviewResponse getReviewComments(Long submissionId, String codeFile) {
         findReviewSubmissionById(submissionId);
 
-        List<ReviewComment> allComments = getAllCommentsBySubmissionAndCodeFile(submissionId, codeFileId);
+        List<ReviewComment> allComments = getAllCommentsBySubmissionAndCodeFile(submissionId, codeFile);
 
         // 부모 댓글들만 필터링 (parentComment가 null인 것들)
         List<ReviewComment> parentComments = allComments.stream()
@@ -362,10 +362,14 @@ public class ReviewServiceImpl implements IReviewService {
     /**
      * 특정 세션과 코드 파일에 대한 모든 댓글을 조회하는 헬퍼 메서드
      */
-    private List<ReviewComment> getAllCommentsBySubmissionAndCodeFile(Long submissionId, Long codeFileId) {
-        if (codeFileId != null) {
+    private List<ReviewComment> getAllCommentsBySubmissionAndCodeFile(Long submissionId, String filePath) {
+        if (filePath != null && !filePath.trim().isEmpty()) {
+            // 파일 경로로 CodeFile 찾기
+            ReviewSubmission reviewSubmission = findReviewSubmissionById(submissionId);
+            CodeFile codeFile = findCodeFileByPath(reviewSubmission, filePath);
+            
             // 특정 코드 파일의 모든 댓글 조회 (부모 댓글과 답글 모두)
-            return reviewCommentRepository.findByReviewSubmissionIdAndCodeFileId(submissionId, codeFileId);
+            return reviewCommentRepository.findByReviewSubmissionIdAndCodeFileId(submissionId, codeFile.getId());
         } else {
             // 세션 레벨 댓글과 그 답글들 조회
             List<ReviewComment> sessionComments = reviewCommentRepository.findByReviewSubmissionIdAndCommentTypeAndCodeFileIsNull(submissionId, ReviewCommentType.SESSION_COMMENT);


### PR DESCRIPTION
## 수정사항

기존에 controller에서 `null`로 처리하던 댓글 부분을 수정했습니다.
filePath로 댓글을 정상적으로 가져올 수 있게 변경했습니다.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/28ef8edf-f04f-4850-9475-9c7dbf0fdf94" />

## 추가

issue template을 설정해달라는 @junepil 의 요청을 반영했습니다.