### PR TITLE
Refactor: Remove reviewerId null validation & fix related issues

### DIFF
--- a/src/main/java/konkuk/ptal/domain/enums/ReviewSubmissionType.java
+++ b/src/main/java/konkuk/ptal/domain/enums/ReviewSubmissionType.java
@@ -1,7 +1,7 @@
 package konkuk.ptal.domain.enums;
 
 public enum ReviewSubmissionType {
-    SENT,
-    RECEIVED,
+    SUBMITTED,
+    REVIEWED,
     ALL
 }

--- a/src/main/java/konkuk/ptal/dto/request/CreateReviewSubmissionRequest.java
+++ b/src/main/java/konkuk/ptal/dto/request/CreateReviewSubmissionRequest.java
@@ -9,7 +9,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class CreateReviewSubmissionRequest {
-    @NotNull(message = "리뷰어 ID는 필수입니다")
     private Long reviewerId;
 
     @Pattern(regexp = "^https?://.*$", message = "올바른 HTTP/HTTPS URL 형식이어야 합니다")

--- a/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
@@ -27,7 +27,7 @@ public class ReadReviewSubmissionResponse {
         BaseAuditResponse baseAuditResponse = BaseAuditResponse.from(reviewSubmission.getCreatedAt());
         return ReadReviewSubmissionResponse.builder()
                 .id(reviewSubmission.getId())
-                .reviewer(ReadReviewerResponse.from(reviewSubmission.getReviewer()))
+                .reviewer(reviewSubmission.getReviewer() != null ? ReadReviewerResponse.from(reviewSubmission.getReviewer()) : null)
                 .reviewee(ReadRevieweeResponse.from(reviewSubmission.getReviewee()))
                 .gitUrl(reviewSubmission.getGitUrl())
                 .branch(reviewSubmission.getBranch())

--- a/src/main/java/konkuk/ptal/entity/ReviewSubmission.java
+++ b/src/main/java/konkuk/ptal/entity/ReviewSubmission.java
@@ -26,7 +26,7 @@ public class ReviewSubmission {
     private Reviewee reviewee;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "reviewer_id", nullable = false)
+    @JoinColumn(name = "reviewer_id")
     private Reviewer reviewer;
 
     @Column(nullable = false)

--- a/src/main/java/konkuk/ptal/repository/ReviewSubmissionRepository.java
+++ b/src/main/java/konkuk/ptal/repository/ReviewSubmissionRepository.java
@@ -1,22 +1,32 @@
 package konkuk.ptal.repository;
 
+import konkuk.ptal.domain.enums.ReviewSubmissionStatus;
 import konkuk.ptal.entity.ReviewSubmission;
 import konkuk.ptal.entity.Reviewee;
 import konkuk.ptal.entity.Reviewer;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface ReviewSubmissionRepository extends JpaRepository<ReviewSubmission, Long> {
-    Optional<ReviewSubmission> findByIdAndReviewee_User_IdOrIdAndReviewer_User_Id(
-            Long submissionId1, Long revieweeUserId,
-            Long submissionId2, Long reviewerUserId
+
+    Optional<ReviewSubmission> findByIdAndReviewer_User_IdOrIdAndReviewerIsNullAndStatus(
+            Long id, Long reviewerUserId, Long id2, ReviewSubmissionStatus pendingStatus
     );
 
+    @Query("SELECT rs FROM ReviewSubmission rs " +
+            "LEFT JOIN rs.reviewer rr " + // Reviewer 조인
+            "WHERE rr.user.id = :userId " + // 조건 1: 나에게 할당된 리뷰
+            "OR (rr IS NULL AND rs.status = :pendingStatus)") // 조건 2: Reviewer가 null이고 PENDING인 리뷰
+    Page<ReviewSubmission> findAllSubmissionsForReviewer(@Param("userId") Long userId,
+                                                         @Param("pendingStatus") ReviewSubmissionStatus pendingStatus,
+                                                         Pageable pageable);
     Optional<ReviewSubmission> findByIdAndReviewee_User_Id(Long submissionId, Long revieweeUserId);
 
     Page<ReviewSubmission> findByReviewee(Reviewee reviewee, Pageable pageable);

--- a/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
@@ -85,14 +85,14 @@ public class ReviewServiceImpl implements IReviewService {
         Page<ReviewSubmission> reviewSubmissionPage;
         switch (type) {
             case SUBMITTED:
-                Reviewee revieweeForSent = revieweeRepository.findByUser_Id(userId)
+                Reviewee submittedReviewee = revieweeRepository.findByUser_Id(userId)
                         .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
-                reviewSubmissionPage = reviewSubmissionRepository.findByReviewee(revieweeForSent, pageable);
+                reviewSubmissionPage = reviewSubmissionRepository.findByReviewee(submittedReviewee, pageable);
                 break;
             case REVIEWED:
-                Reviewer reviewerForReceived = reviewerRepository.findByUser_Id(userId)
+                Reviewer reviewedReviewer = reviewerRepository.findByUser_Id(userId)
                         .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
-                reviewSubmissionPage = reviewSubmissionRepository.findByReviewer(reviewerForReceived, pageable);
+                reviewSubmissionPage = reviewSubmissionRepository.findByReviewer(reviewedReviewer, pageable);
                 break;
             case ALL:
             default:

--- a/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
@@ -42,27 +42,40 @@ public class ReviewServiceImpl implements IReviewService {
                 .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
         Reviewee reviewee = revieweeRepository.findByUser_Id(user.getId())
                 .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
-        Reviewer reviewer = reviewerRepository.findById(request.getReviewerId())
-                .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
 
+        Reviewer reviewer = null;
+        if (request.getReviewerId() != null) {
+            reviewer = reviewerRepository.findById(request.getReviewerId())
+                    .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
+        }
         ReviewSubmission reviewSubmission = ReviewSubmission.createReviewSubmission(ReviewSubmissionStatus.PENDING, reviewer, reviewee, request);
         reviewSubmission = reviewSubmissionRepository.save(reviewSubmission);
-
         fileService.createCodeFilesForSubmission(reviewSubmission);
 
         return reviewSubmission;
+
     }
 
     @Override
     @Transactional(readOnly = true)
     public ReviewSubmission getReviewSubmission(Long submissionId, UserPrincipal userPrincipal) {
         Long userId = userPrincipal.getUserId();
-        return reviewSubmissionRepository
-                .findByIdAndReviewee_User_IdOrIdAndReviewer_User_Id(
-                        submissionId, userId,
-                        submissionId, userId
-                )
-                .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
+        Optional<Reviewer> reviewer = reviewerRepository.findByUser_Id(userId);
+
+        ReviewSubmission reviewSubmission;
+
+        if (reviewer.isPresent()) {
+            reviewSubmission = reviewSubmissionRepository
+                    .findByIdAndReviewer_User_IdOrIdAndReviewerIsNullAndStatus(
+                            submissionId, userId, submissionId, ReviewSubmissionStatus.PENDING
+                    )
+                    .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
+        } else {
+            reviewSubmission = reviewSubmissionRepository
+                    .findByIdAndReviewee_User_Id(submissionId, userId)
+                    .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
+        }
+        return reviewSubmission;
     }
 
     @Override
@@ -83,7 +96,14 @@ public class ReviewServiceImpl implements IReviewService {
                 break;
             case ALL:
             default:
-                reviewSubmissionPage = reviewSubmissionRepository.findByReviewee_User_IdOrReviewer_User_Id(userId, userId, pageable);
+                Optional<Reviewer> currentReviewer = reviewerRepository.findByUser_Id(userId);
+                if (currentReviewer.isPresent()) {
+                    reviewSubmissionPage = reviewSubmissionRepository.findAllSubmissionsForReviewer(userId, ReviewSubmissionStatus.PENDING, pageable);
+                }else{
+                    Reviewee reviewee = revieweeRepository.findByUser_Id(userId)
+                            .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
+                    reviewSubmissionPage = reviewSubmissionRepository.findByReviewee(reviewee, pageable);
+                }
                 break;
         }
         List<ReadReviewSubmissionResponse> content = reviewSubmissionPage.getContent().stream()
@@ -108,7 +128,8 @@ public class ReviewServiceImpl implements IReviewService {
                 .findByIdAndReviewee_User_Id(submissionId, userId)
                 .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
 
-        if (reviewSubmission.getStatus() != ReviewSubmissionStatus.PENDING) {
+        if (reviewSubmission.getStatus() != ReviewSubmissionStatus.PENDING &&
+                reviewSubmission.getStatus() != ReviewSubmissionStatus.APPROVED) {
             throw new BadRequestException(SUBMISSION_CANCEL_UNAVAILABLE);
         }
 
@@ -126,6 +147,18 @@ public class ReviewServiceImpl implements IReviewService {
         // 인증된 사용자 정보를 가져옴
         User user = findUserById(userPrincipal.getUserId());
 
+        if (reviewSubmission.getStatus() == ReviewSubmissionStatus.PENDING) {
+            reviewSubmission.setStatus(ReviewSubmissionStatus.APPROVED);
+        }
+
+        if (reviewSubmission.getReviewer() == null) {
+            Optional<Reviewer> optionalReviewer = reviewerRepository.findByUser_Id(user.getId());
+            if (optionalReviewer.isPresent()) {
+                Reviewer actualReviewer = optionalReviewer.get();
+                reviewSubmission.setReviewer(actualReviewer);
+                reviewSubmissionRepository.save(reviewSubmission);
+            }
+        }
         CodeFile codeFile = null;
         ReviewCommentType commentType;
 
@@ -229,7 +262,9 @@ public class ReviewServiceImpl implements IReviewService {
                 .findByIdAndReviewer_User_Id(submissionId, userId)
                 .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
 
-        if (reviewSubmission.getStatus() != ReviewSubmissionStatus.PENDING) {
+        // PENDING 또는 APPROVED 상태일 때만 리뷰 생성을 허용합니다.
+        if (reviewSubmission.getStatus() != ReviewSubmissionStatus.PENDING &&
+                reviewSubmission.getStatus() != ReviewSubmissionStatus.APPROVED) {
             throw new BadRequestException(REVIEW_UNAVAILABLE);
         }
 

--- a/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
@@ -84,12 +84,12 @@ public class ReviewServiceImpl implements IReviewService {
         Pageable pageable = PageRequest.of(page, size);
         Page<ReviewSubmission> reviewSubmissionPage;
         switch (type) {
-            case SENT:
+            case SUBMITTED:
                 Reviewee revieweeForSent = revieweeRepository.findByUser_Id(userId)
                         .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
                 reviewSubmissionPage = reviewSubmissionRepository.findByReviewee(revieweeForSent, pageable);
                 break;
-            case RECEIVED:
+            case REVIEWED:
                 Reviewer reviewerForReceived = reviewerRepository.findByUser_Id(userId)
                         .orElseThrow(() -> new EntityNotFoundException(ENTITY_NOT_FOUND));
                 reviewSubmissionPage = reviewSubmissionRepository.findByReviewer(reviewerForReceived, pageable);

--- a/src/main/resources/static/openapi.yaml
+++ b/src/main/resources/static/openapi.yaml
@@ -1790,11 +1790,11 @@ paths:
         - name: type
           in: query
           required: false
-          description: "조회할 제출 목록의 타입. `sent`: 내가 보낸 요청, `received`: 내가 받은 요청 (리뷰어만 해당), `all`: 나와 관련된 모든 요청. 기본값은 `all` 또는 사용자의 역할에 따라 적절히 설정될 수 있습니다."
+          description: "조회할 제출 목록의 타입. `SUBMITTED`: 내가 보낸 요청, `REVIEWED`: 내가 받은 요청 (리뷰어만 해당), `ALL`: 나와 관련된 모든 요청. 기본값은 `ALL` 또는 사용자의 역할에 따라 적절히 설정될 수 있습니다."
           schema:
             type: string
-            enum: [sent, received, all]
-            example: "sent"
+            enum: [SUBMITTED, REVIEWED, ALL]
+            example: "SUBMITTED"
         - name: page
           in: query
           required: false


### PR DESCRIPTION
### Related to:
- #77 

### 주요 변경사항:
- 리뷰 요청 시 `reviewerId`가 `null` 값도 허용하도록 수정
- 관련 API 및 비즈니스 로직 수정
  - `validateReviewSubmissionAccess` 에서 역할에 따른 `access` 조건 수정
  - `createReviewSubmission` & `getReviewSubmission` & `getReviewSubmissions` & `createReviewComment` 에서 역할에 따른 로직 수정
  - ReviewSubmission에 comment가 달릴 때 Reviewer 추가 및 status를 `PENDING` -> `APPROVED`로 수정
 
### Note:
`Review Submission`들을 조회할 때 `status`에 따른 구분
- `SENT` : 리뷰이 자신이 보낸 `submission`들 조회
- `RECEIVED` : 리뷰어 자신이 받은 `submission`들 조회
- `ALL OR DEFAULT`: 
  - 리뷰이: `SENT`와 동일
  - 리뷰어: `REVEIVED` 의 경우 + `ReviewSubmission`의 `reviewer`가 `null` 이면서 `status`가 `PENDING`들도 함께 조회 