### PR TITLE
파일시스템 정보를 목록 조회에서 제외

### DIFF
--- a/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
+++ b/src/main/java/konkuk/ptal/dto/response/ReadReviewSubmissionResponse.java
@@ -22,6 +22,22 @@ public class ReadReviewSubmissionResponse {
     LocalDateTime createdAt;
     LocalDateTime updatedAt;
 
+    public static ReadReviewSubmissionResponse from(ReviewSubmission reviewSubmission) {
+
+        BaseAuditResponse baseAuditResponse = BaseAuditResponse.from(reviewSubmission.getCreatedAt());
+        return ReadReviewSubmissionResponse.builder()
+                .id(reviewSubmission.getId())
+                .reviewer(ReadReviewerResponse.from(reviewSubmission.getReviewer()))
+                .reviewee(ReadRevieweeResponse.from(reviewSubmission.getReviewee()))
+                .gitUrl(reviewSubmission.getGitUrl())
+                .branch(reviewSubmission.getBranch())
+                .requestDetails(reviewSubmission.getRequestDetails())
+                .status(reviewSubmission.getStatus())
+                .createdAt(baseAuditResponse.getCreatedAt())
+                .updatedAt(baseAuditResponse.getUpdatedAt())
+                .build();
+    }
+
     public static ReadReviewSubmissionResponse from(ReviewSubmission reviewSubmission, ProjectFileSystemResponse fileSystem) {
 
         BaseAuditResponse baseAuditResponse = BaseAuditResponse.from(reviewSubmission.getCreatedAt());

--- a/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
+++ b/src/main/java/konkuk/ptal/service/ReviewServiceImpl.java
@@ -87,14 +87,7 @@ public class ReviewServiceImpl implements IReviewService {
                 break;
         }
         List<ReadReviewSubmissionResponse> content = reviewSubmissionPage.getContent().stream()
-                .map(submission -> {
-                    ProjectFileSystemResponse fileSystem = fileService.getProjectFileSystem(
-                            submission.getGitUrl(),
-                            submission.getBranch(),
-                            submission.getId()
-                    );
-                    return ReadReviewSubmissionResponse.from(submission, fileSystem);
-                })
+                .map(ReadReviewSubmissionResponse::from)
                 .collect(Collectors.toList());
 
         return new ListReviewSubmissionResponse(reviewSubmissionPage, content);


### PR DESCRIPTION
## 수정사항

- `ReadReviewSubmissionResponse` DTO에서 `filesystem` 정보를 포함하지 않는 `from()` 메서드 오버로딩
- `ReviewService`에서 오버로딩한 메서드를 호출하도록 변경